### PR TITLE
Update API to match common schema definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Repository to describe, develop, document and test the Device Identifier API fam
 
 ## Results
 * Sub Project is in progress
-* Draft 0.4.0 of the Device Identifier API is available within the [main branch](https://github.com/camaraproject/DeviceIdentifier):
+* Draft 0.5.0 of the Device Identifier API is available within the [main branch](https://github.com/camaraproject/DeviceIdentifier):
   - API definition **with inline documentation**:
     - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceIdentifier/blob/main/code/API_definitions/CAMARA%20Mobile%20Device%20Identifier%20API.yaml)
     - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/main/code/API_definitions/CAMARA%20Mobile%20Device%20Identifier%20API.yaml&nocors)

--- a/code/API_definitions/CAMARA Mobile Device Identifier API.yaml
+++ b/code/API_definitions/CAMARA Mobile Device Identifier API.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: CAMARA Mobile Device Identifier API
-  version: 0.4.0
+  version: 0.5.0
   description: |
     # Summary
 
@@ -96,14 +96,11 @@ externalDocs:
   url: https://github.com/camaraproject/DeviceIdentifier
 
 servers:
-  - url: "{apiRoot}/{basePath}"
+  - url: "{apiRoot}/device-identifier/v0"
     variables:
       apiRoot:
         default: https://localhost:443
         description: API root
-      basePath:
-        default: device-identifier/v0
-        description: Base path for the Device Identifier API
 
 paths:
   "/get-device-identifier":
@@ -410,25 +407,22 @@ components:
     Device:
       description: |
         End-user equipment able to connect to a mobile network. Examples of devices include smartphones or IoT sensors/actuators.
-
         The developer can choose to provide the below specified device identifiers:
-
+        * `ipv4Address`
+        * `ipv6Address`
         * `phoneNumber`
         * `networkAccessIdentifier`
-        * `ipv6Address`
-        * `ipv4Address`
-
-        NOTE: The API implementation might support only a subset of these options. The API consumer can provide multiple identifiers to be compatible across different implementations. In this case the identifiers MUST belong to the same device. In the event that the identifiers belong to different devices, an error may be returned, or the API implementation may take the identifiers specified in the order defined above until it finds a valid identifier.
+        NOTE: the MNO might support only a subset of these options. The API invoker can provide multiple identifiers to be compatible across different MNOs. In this case the identifiers MUST belong to the same device.
       type: object
       properties:
         phoneNumber:
           $ref: "#/components/schemas/PhoneNumber"
         networkAccessIdentifier:
           $ref: "#/components/schemas/NetworkAccessIdentifier"
-        ipv6Address:
-          $ref: "#/components/schemas/Ipv6Address"
         ipv4Address:
           $ref: "#/components/schemas/DeviceIpv4Addr"
+        ipv6Address:
+          $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
 
     DeviceIpv4Addr:
@@ -470,21 +464,6 @@ components:
           type: string
           description: This parameter appears when there was an error. Human readable explanation specific to this occurrence of the problem
 
-    Ipv6Address:
-      type: string
-      allOf:
-        - pattern: '^((:|(0?|([1-9a-f][0-9a-f]{0,3}))):)((0?|([1-9a-f][0-9a-f]{0,3})):){0,6}(:|(0?|([1-9a-f][0-9a-f]{0,3})))(\/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))?$'
-        - pattern: '^((([^:]+:){7}([^:]+))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?))(\/.+)?$'
-      example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
-      description: |
-        IPv6 address, following IETF 5952 format, may be specified in form <address/mask> as:
-          - address - The /128 subnet is optional for single addresses:
-            - 2001:db8:85a3:8d3:1319:8a2e:370:7344
-            - 2001:db8:85a3:8d3:1319:8a2e:370:7344/128
-          - address/mask - an IP v6 number with a mask:
-            - 2001:db8:85a3:8d3::0/64
-            - 2001:db8:85a3:8d3::/64
-
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
       type: string
@@ -505,5 +484,12 @@ components:
     SingleIpv4Addr:
       description: A single IPv4 address with no subnet mask
       type: string
-      pattern: '^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$'
+      format: ipv4
       example: "84.125.93.10"
+
+    DeviceIpv6Address:
+      description: |
+        The device should be identified by the observed IPv6 address, or by any single IPv6 address from within the subnet allocated to the device (e.g. adding ::0 to the /64 prefix).
+      type: string
+      format: ipv6
+      example: 2001:db8:85a3:8d3:1319:8a2e:370:7344


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Current schema do not match those in the common date types schema definitions.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Update API to match common schema definitions
```

#### Additional documentation 
N/A