### PR TITLE
Update MAINTAINERS.MD

### DIFF
--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -1,4 +1,4 @@
-| Org                    | Name                                                |
-| -----------------------| ----------------------------------------------------|
-| Vodafone| Kevin Smith |
-| Vodafone| Eric Murray |
+| Org      | Name        | Github Name  |
+| -------- | ----------- | -----------  |
+| Vodafone | Kevin Smith | @Kevsy       |
+| Vodafone | Eric Murray | @eric-murray |


### PR DESCRIPTION
#### What type of PR is this?
* subproject management

#### What this PR does / why we need it:
To help automate sub-project management, the github user name of sub-project maintainers is required.

#### Which issue(s) this PR fixes:
None

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Add github user names to Maintainers file
```

#### Additional documentation 
None