### PR TITLE
Update CAMARA Mobile Device Identifier API.yaml

### DIFF
--- a/code/API_definitions/CAMARA Mobile Device Identifier API.yaml
+++ b/code/API_definitions/CAMARA Mobile Device Identifier API.yaml
@@ -135,7 +135,6 @@ paths:
           required: false
           schema:
             type: string
-            format: uuid
 
       requestBody:
         description: Parameters to create a new session
@@ -188,7 +187,6 @@ paths:
           required: false
           schema:
             type: string
-            format: uuid
 
       requestBody:
         description: Parameters to create a new session
@@ -235,7 +233,6 @@ components:
       required: false
       schema:
         type: string
-        format: uuid
 
   responses:
     200RetrieveIdentifier:


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities v0.4.0 allows x-correlator to be any string, and not restricted to being a uuid. Therefore `format: uuid` needs to be removed from the definition.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Remove `format: uuid` from x-correlator definition
```

#### Additional documentation 
None