### PR TITLE
Add EUDI Wallet and Mobile Device Insurance User Stories

### DIFF
--- a/documentation/API_documentation/Device Identifier User Story.md
+++ b/documentation/API_documentation/Device Identifier User Story.md
@@ -9,6 +9,17 @@
 | ***Post-Conditions*** | None  |
 | ***Exceptions*** | Several exceptions might occur after a request to the Device Identifier API<br>- **Unauthorized**: Invalid credentials (e.g. use of already expired access token).<br>- **Invalid Input**: Invalid input data to retrieve device details (e.g. MSISDN format not as expected, or MSISDN not associated with a customer of the CSP).<br>- **Forbidden**: End user has not consented to device identifier information being provided to the Customer:User|
 
+# EUDI Wallet Device-Binding User Story
+
+| **Item** | **Details** |
+| ---- | ------- |
+| ***Summary*** | As an application developer working for an EUDI Wallet provider, I want to bind the user's wallet to their device. For that purpose I want to retrieve the device identifier of the user's device. |
+| ***Roles, Actors and Scope*** | **Roles:** Customer:User<br> **Actors:** Application Service Providers, Hyperscalers, Application Developers, End Users<br> **Scope:** *Order To Activate (OTA)* \- Retrieve device identifier details |
+| ***Pre-Conditions*** |The preconditions are listed below:<br><ol><li>The Customer:BusinessManager and Customer:Administrator have been onboarded to the CSP's API platform.</li><li>The Customer:BusinessManager has successfully subscribed to the Device Identifier product from the product catalog.</li><li>The Customer:Administrator has onboarded the Customer:User to the platform.</li><li>The Customer:BusinessManager has agreed to the terms and conditions of the CSP for managing consent of mobile subscription owners.</li><li>The means to get the access token are known to the Customer:User to ensure secure access of the API.|
+| ***Activities/Steps*** | **Starts when:** The Customer:User has installed the EUDI Wallet and the wallet runs for the first time. The EUDI Wallet retrieves an access-token using OIDC authentication code flow and creates a POST request to the DeviceIdentifier API to retrieve the device identifer.<br>**Ends when:** The Device Identifier API returns the requested information, or an error message |
+| ***Post-Conditions*** | None  |
+| ***Exceptions*** | Several exceptions might occur after a request to the Device Identifier API<br>- **Unauthorized**: Invalid credentials (e.g. use of already expired access token).<br>- **Invalid Input**: Invalid input data to retrieve device details (e.g. MSISDN format not as expected, or MSISDN not associated with a customer of the CSP).<br>- **Forbidden**: End user has not consented to device identifier information being provided to the Customer:User|
+
 # Device Type API User Story
 
 | **Item** | **Details** |

--- a/documentation/API_documentation/Device Identifier User Story.md
+++ b/documentation/API_documentation/Device Identifier User Story.md
@@ -30,3 +30,15 @@
 | ***Activities/Steps*** | **Starts when:** The Customer:User's application server makes a POST request to the Device Type API containing the end user's subscription information in the request body in order to retrieve the device TAC plus any optional device information.<br>**Ends when:** The Device Type API returns the requested information, or an error message |
 | ***Post-Conditions*** | None  |
 | ***Exceptions*** | Several exceptions might occur after a request to the Device Type API<br>- **Unauthorized**: Invalid credentials (e.g. use of already expired access token).<br>- **Invalid Input**: Invalid input data to retrieve device details (e.g. MSISDN format not as expected, or MSISDN not associated with a customer of the CSP).<br>- **Forbidden**: End user has not consented to device TAC information being provided to the Customer:User|
+
+# Mobile Device Insurance User Story
+
+| **Item** | **Details** |
+| ---- | ------- |
+| ***Summary*** | As an application developer working for an insurance company that insures mobile devices, I want to retrieve the device identifier and the model and make of the user's device. The retrieved information is used in creating the contract between the insurance company and the user, and also when the user reports the device to be e.g. damaged or stolen. |
+| ***Roles, Actors and Scope*** | **Roles:** Customer:User<br> **Actors:** Application Service Providers, Hyperscalers, Application Developers, End Users<br> **Scope:** *Order To Activate (OTA)* \- Retrieve device type details |
+| ***Pre-Conditions*** |The preconditions are listed below:<br><ol><li>The Customer:BusinessManager and Customer:Administrator have been onboarded to the CSP's API platform.</li><li>The Customer:BusinessManager has successfully subscribed to the Device Type product from the product catalog.</li><li>The Customer:Administrator has onboarded the Customer:User to the platform.</li><li>The Customer:BusinessManager has agreed to the terms and conditions of the CSP for managing consent of mobile subscription owners.</li><li>The means to get the access token are known to the Customer:User to ensure secure access of the API.|
+| ***Activities/Steps*** | **Starts when:** The Customer:Applicatoin requests an access token using OIDC authorization code flow and then uses the DeviceIdentifier API to retrieve device identifier and model and make of the user's devive.<br>**Ends when:** The Device Type API returns the requested information, or an error message |
+| ***Post-Conditions*** | None  |
+| ***Exceptions*** | Several exceptions might occur after a request to the Device Type API<br>- **Unauthorized**: Invalid credentials (e.g. use of already expired access token).<br>- **Invalid Input**: Invalid input data to retrieve device details (e.g. MSISDN format not as expected, or MSISDN not associated with a customer of the CSP).<br>- **Forbidden**: End user has not consented to device TAC information being provided to the Customer:User|
+


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation

#### What this PR does / why we need it:
This PR adds two user stories. One is an EUDI Wallet user story, in which the DeviceIdentifier API is used to retrieve the device identifier to bind the user's device to the EUDI Wallet. The second user story is about an mobile device insurance company which uses the DeviceIdentifier API to retrieve the device identifier and the model and the make of the device the insurance company's mobile application is running on.

#### Special notes for reviewers:

These user stories are more specific than the previously existing user stories.
The previous user stories followed the lines of "As a developer I want to use API" while the two new user stories also contain the why and purpose of using the API.

