### PR TITLE
 Fixes the missing `required` property in the the error response schema

### DIFF
--- a/code/API_definitions/CAMARA Mobile Device Identifier API.yaml
+++ b/code/API_definitions/CAMARA Mobile Device Identifier API.yaml
@@ -647,6 +647,10 @@ components:
         message:
           type: string
           description: This parameter appears when there was an error. Human readable explanation specific to this occurrence of the problem
+      required:
+        - code
+        - status
+        - message
 
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
 Fixes the missing `required` property in the the error response schema

#### Which issue(s) this PR fixes:

Fixes #74

#### Special notes for reviewers:

None

#### Changelog input

```
 release-note
-  Fixes the missing `required` property in the the error response schema
```



