### PR TITLE
Add global tag definitions to OAS definition

### DIFF
--- a/code/API_definitions/CAMARA Mobile Device Identifier API.yaml
+++ b/code/API_definitions/CAMARA Mobile Device Identifier API.yaml
@@ -139,6 +139,10 @@ servers:
         default: https://localhost:443
         description: API root, to be defined by the service provider
 
+tags:
+  - name: Get Device Identifiers
+    description: Retrieve details about the device being used by a mobile subscriber
+
 paths:
   "/retrieve-identifier":
     post:


### PR DESCRIPTION
#### What type of PR is this?
* documentation

#### What this PR does / why we need it:
Add global tag definitions to avoid annoying linting warning

#### Which issue(s) this PR fixes:
N/A

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Add global tag definitions to avoid annoying linting warning
```

#### Additional documentation 
None