### PR TITLE
Prepare pre-release r1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The API definition(s) are based on
 * Commonalities v0.4.0
 * Identity and Consent Management v0.2.1
 
-## quality-on-demand v0.2.0-alpha.1
+## device-identifier v0.2.0-alpha.1
 
 Version 0.2.0-alpha.1 contains many small changes for compliance with Commonalities v0.4.0 and Identity and Consent Management v0.2.1. **There are breaking changes compared to v0.1.0.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog DeviceIdentifier
+
+## Table of Contents
+- **[r2.1](#r21)**
+- [v0.1.0](#v010)
+
+**Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
+
+# r2.1
+## Release Notes
+
+This public release contains the definition and documentation of
+* device-identifier v0.2.0-alpha.1
+
+The API definition(s) are based on
+* Commonalities v0.4.0
+* Identity and Consent Management v0.2.1
+
+## quality-on-demand v0.2.0-alpha.1
+
+Version 0.2.0-alpha.1 contains many small changes for compliance with Commonalities v0.4.0 and Identity and Consent Management v0.2.1. **There are breaking changes compared to v0.1.0.**
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r2.1/code/API_definitions/device-identifier.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r2.1/code/API_definitions/device-identifier.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceIdentifier/blob/r2.1/code/API_definitions/device-identifier.yaml)
+
+### Added
+* Create Device Identifier User Story.md by @eric-murray in https://github.com/camaraproject/DeviceIdentifier/pull/59
+* Add EUDI Wallet and Mobile Device Insurance User Stories by @AxelNennker in https://github.com/camaraproject/DeviceIdentifier/pull/73
+* Initial Test Definitions for DeviceIdentifier retrieve identifier by @AxelNennker in https://github.com/camaraproject/DeviceIdentifier/pull/72
+* Add global tag definitions to OAS definition by @eric-murray in https://github.com/camaraproject/DeviceIdentifier/pull/83
+
+### Changed
+* Rename `X-Correlator` header to `x-correlator` by @eric-murray in https://github.com/camaraproject/DeviceIdentifier/pull/62
+* Incorporate Commonalities WG recommendations on Simplification of Device object by @eric-murray in https://github.com/camaraproject/DeviceIdentifier/pull/64
+* Reduce telco language in the API description by @eric-murray in https://github.com/camaraproject/DeviceIdentifier/pull/77
+* Rewrite text around treatment of primary / secondary MSISDN by @eric-murray in https://github.com/camaraproject/DeviceIdentifier/pull/76
+* Update `info` section of OAS to comply with Commonalities guidelines v0.4.0 by @eric-murray in https://github.com/camaraproject/DeviceIdentifier/pull/66
+* Rename CAMARA Mobile Device Identifier API.yaml to device-identifier.yaml by @eric-murray in https://github.com/camaraproject/DeviceIdentifier/pull/84
+
+### Fixed
+* Fixes the missing `required` property in the the error response schema by @sfnuser in https://github.com/camaraproject/DeviceIdentifier/pull/75
+* Remove `format: uuid` from x-correlator definition by @eric-murray in https://github.com/camaraproject/DeviceIdentifier/pull/67
+
+### Removed
+* Remove 405 error response from YAML by @eric-murray in https://github.com/camaraproject/DeviceIdentifier/pull/81
+
+**Full Changelog**: https://github.com/camaraproject/DeviceIdentifier/compare/device-identifier-0.1.0...r2.1
+
+# v0.1.0
+## Release Notes
+
+This pre-release contains the first initial version v0.1.0 of the Device Identifier API.
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/device-identifier-0.1.0/code/API_definitions/CAMARA%20Mobile%20Device%20Identifier%20API.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/device-identifier-0.1.0/code/API_definitions/CAMARA%20Mobile%20Device%20Identifier%20API.yaml)
+  - [OpenAPI YAML spec file](https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/device-identifier-0.1.0/code/API_definitions/CAMARA%20Mobile%20Device%20Identifier%20API.yaml)
+
+- This pre-release is intended to be compliant with:
+  - Commonalities Release [0.3.0](https://github.com/camaraproject/Commonalities/releases/tag/v0.3.0)
+  - Identity and Consent Management Release [0.1.0](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/v0.1.0)
+
+# Main Changes
+- New endpoint /retrieve-identifier to retrieve an identifier (IMEI) and other optional details for the device associated with a specified end user subscription (e.g. MSISDN)
+- New endpoint /retrieve-type to retrieve the device type (TAC - Type Approval Code) and other optional details for the device associated with a specified end user subscription
+
+# Added
+- Added endpoint /retrieve-identifier added by @eric-murray in PR https://github.com/camaraproject/DeviceIdentifier/pull/55
+- Added endpoint /retrieve-type added by @eric-murray in PR https://github.com/camaraproject/DeviceIdentifier/pull/55
+
+# Changed
+- Update README.MD by @Kevsy in PR https://github.com/camaraproject/DeviceIdentifier/pull/39
+
+# Fixed
+- Typo fixes by @deeokonkwo in PR https://github.com/camaraproject/DeviceIdentifier/pull/50
+
+# Removed
+- N/A
+
+Full Changelog: https://github.com/camaraproject/DeviceIdentifier/commits/device-identifier-0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog DeviceIdentifier
 
 ## Table of Contents
-- **[r2.1](#r21)**
+- **[r1.1](#r11)**
 - [v0.1.0](#v010)
 
 **Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
 
-# r2.1
+# r1.1
 ## Release Notes
 
 This public release contains the definition and documentation of
@@ -21,9 +21,9 @@ The API definition(s) are based on
 Version 0.2.0-alpha.1 contains many small changes for compliance with Commonalities v0.4.0 and Identity and Consent Management v0.2.1. **There are breaking changes compared to v0.1.0.**
 
 - API definition **with inline documentation**:
-  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r2.1/code/API_definitions/device-identifier.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r2.1/code/API_definitions/device-identifier.yaml)
-  - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceIdentifier/blob/r2.1/code/API_definitions/device-identifier.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r1.1/code/API_definitions/device-identifier.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r1.1/code/API_definitions/device-identifier.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceIdentifier/blob/r1.1/code/API_definitions/device-identifier.yaml)
 
 ### Added
 * Create Device Identifier User Story.md by @eric-murray in https://github.com/camaraproject/DeviceIdentifier/pull/59
@@ -46,7 +46,7 @@ Version 0.2.0-alpha.1 contains many small changes for compliance with Commonalit
 ### Removed
 * Remove 405 error response from YAML by @eric-murray in https://github.com/camaraproject/DeviceIdentifier/pull/81
 
-**Full Changelog**: https://github.com/camaraproject/DeviceIdentifier/compare/device-identifier-0.1.0...r2.1
+**Full Changelog**: https://github.com/camaraproject/DeviceIdentifier/compare/device-identifier-0.1.0...r1.1
 
 # v0.1.0
 ## Release Notes

--- a/README.md
+++ b/README.md
@@ -10,24 +10,32 @@ Repository to describe, develop, document and test the Device Identifier API fam
 
 ## Scope
 * Service APIs for “Device Identifier API” (see [API Proposal](https://github.com/camaraproject/APIBacklog/blob/main/documentation/API%20proposals/APIproposal_DeviceIdentifier_Vodafone.md))
-* Describe, develop, document and test the APIs (with 1-2 Telcos)  
+* It provides the customer with the ability to:
+  * Retrieve the current identity (IMEI) of the mobile device being used by a given mobile subscriber
+  * Retrieve the type (manufacturer and model) of the mobile device being used by a given mobile subscriber
+* Describe, develop, document and test the APIs (with 1-2 Service Providers)  
 * Started: October 2022
 
 ## Project Wiki
-* The project wiki can be found [here](https://wiki.camaraproject.org/display/CAM/DeviceIdentifier)
+* The project wiki can be found [here](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14561907/DeviceIdentifier)
 
 ## Meetings
 * Schedule: First Friday of each month at 09:00 BST / 10:00 CEST via Linux Foundation Zoom service
  * Meeting invite can be found [here](https://github.com/camaraproject/DeviceIdentifier/blob/main/documentation/MeetingMinutes/CAMARA%20Device%20Identifier%20Monthly%20Meeting.ics)
- * Meeting minutes can be found [here](https://wiki.camaraproject.org/display/CAM/DeviceIdentifier+Meeting+Minutes)
+ * Meeting minutes can be found [here](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14564298/DeviceIdentifier+Meeting+Minutes)
 
-## Results
-* **Device Identifier API**
-  - Current work-in-progress version is available within the [main branch](https://github.com/camaraproject/DeviceIdentifier)
-    - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceIdentifier/blob/main/code/API_definitions/CAMARA%20Mobile%20Device%20Identifier%20API.yaml)
-    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/main/code/API_definitions/CAMARA%20Mobile%20Device%20Identifier%20API.yaml&nocors)
-    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/main/code/API_definitions/CAMARA%20Mobile%20Device%20Identifier%20API.yaml)
-  - Initial release 0.1.0 is available [here](https://github.com/camaraproject/DeviceIdentifier/releases/tag/device-identifier-0.1.0)
+## Release Information
+
+* Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest public release**.
+
+* **The latest public pre-release is [r2.1](https://github.com/camaraproject/DeviceIdentifier/tree/r2.1) with the following API definitions:**
+
+  * **device-identifier v0.2.0-alpha.1**
+  [[YAML]](https://github.com/camaraproject/DeviceIdentifier/blob/r2.1/code/API_definitions/device-identifier.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r2.1/code/API_definitions/device-identifier.yaml&nocors)
+  [[View it on Swagger Editor]](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r2.1/code/API_definitions/device-identifier.yaml)
+
+- Current work-in-progress version is available within the [main branch](https://github.com/camaraproject/DeviceIdentifier)
 
 ## Contributorship and mailing list
 * To subscribe / unsubscribe to the mailing list of this Sub Project and thus be / resign as Contributor please visit <https://lists.camaraproject.org/g/sp-dvi>.

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Repository to describe, develop, document and test the Device Identifier API fam
 
 * **The latest public pre-release is [r2.1](https://github.com/camaraproject/DeviceIdentifier/tree/r2.1) with the following API definitions:**
 
-  * **device-identifier v0.2.0-alpha.1**
+  * **device-identifier v0.2.0-alpha.1**  
   [[YAML]](https://github.com/camaraproject/DeviceIdentifier/blob/r2.1/code/API_definitions/device-identifier.yaml)
   [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r2.1/code/API_definitions/device-identifier.yaml&nocors)
   [[View it on Swagger Editor]](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r2.1/code/API_definitions/device-identifier.yaml)
 
 - Current work-in-progress version is available within the [main branch](https://github.com/camaraproject/DeviceIdentifier)
 
-## Contributorship and mailing list
+## Contributorship and Mailing List
 * To subscribe / unsubscribe to the mailing list of this Sub Project and thus be / resign as Contributor please visit <https://lists.camaraproject.org/g/sp-dvi>.
 * A message to all Contributors of this Sub Project can be sent using <sp-dvi@lists.camaraproject.org>.

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Repository to describe, develop, document and test the Device Identifier API fam
 
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest public release**.
 
-* **The latest public pre-release is [r2.1](https://github.com/camaraproject/DeviceIdentifier/tree/r2.1) with the following API definitions:**
+* **The latest public pre-release is [r1.1](https://github.com/camaraproject/DeviceIdentifier/tree/r1.1) with the following API definitions:**
 
   * **device-identifier v0.2.0-alpha.1**  
-  [[YAML]](https://github.com/camaraproject/DeviceIdentifier/blob/r2.1/code/API_definitions/device-identifier.yaml)
-  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r2.1/code/API_definitions/device-identifier.yaml&nocors)
-  [[View it on Swagger Editor]](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r2.1/code/API_definitions/device-identifier.yaml)
+  [[YAML]](https://github.com/camaraproject/DeviceIdentifier/blob/r1.1/code/API_definitions/device-identifier.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r1.1/code/API_definitions/device-identifier.yaml&nocors)
+  [[View it on Swagger Editor]](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r1.1/code/API_definitions/device-identifier.yaml)
 
 - Current work-in-progress version is available within the [main branch](https://github.com/camaraproject/DeviceIdentifier)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Repository to describe, develop, document and test the Device Identifier API family
 
 ## Scope
-* Service APIs for “Device Identifier API” (see [API Proposal](https://github.com/camaraproject/APIBacklog/blob/main/documentation/API%20proposals/APIproposal_DeviceIdentifier_Vodafone.md))
+* Service APIs for “Device Identifier API” (see [API Backlog](https://github.com/camaraproject/APIBacklog/blob/main/documentation/APIbacklog.md))
 * It provides the customer with the ability to:
   * Retrieve the current identity (IMEI) of the mobile device being used by a given mobile subscriber
   * Retrieve the type (manufacturer and model) of the mobile device being used by a given mobile subscriber

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -36,7 +36,7 @@ info:
     - the subscription network access identifier, which is a domain specific identifier typically allocated to devices that do not require voice / SMS connectivity
     - the current IP address and port alloacted to the device, which must be an IPv6 or public IPv4 address
 
-    The API can be called by an application server or other 3rd party server to establish the identity of the device currently being used by the mobile subscription. The information returned will depend upon the consent that the end user (i.e. mobile subscription owner) has given for that information to be provided to the API consumer. For example, if the end user has not consented to any information about their device being given, then the API consumer will receive an error in reponse to their request. Otherwise, the information that the end user has consented to being given will be returned.
+    The API can be called by an API consumer to establish the identity of the physical device currently being used by the mobile subscription. The information returned will depend upon the consent that the end user (i.e. mobile subscription owner) has given for that information to be provided to the API consumer. For example, if the end user has not consented to any information about their device being given, then the API consumer will receive an error in response to their request. Otherwise, the information that the end user has consented to being given will be returned.
 
     # Relevant terms and definitions
 

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: CAMARA Mobile Device Identifier
-  version: wip
+  version: 0.2.0-alpha.1
   description: |
     # Summary
 
@@ -133,7 +133,7 @@ externalDocs:
   url: https://github.com/camaraproject/DeviceIdentifier
 
 servers:
-  - url: "{apiRoot}/device-identifier/vwip"
+  - url: "{apiRoot}/device-identifier/v0.2alpha1"
     variables:
       apiRoot:
         default: https://localhost:443

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -99,7 +99,7 @@ info:
 
     If the end user has not consented to the API consumer getting access to the device identifier information, then a `403 PERMISSION_DENIED` error is returned.
 
-    Otherwise, a JSON object is returned containing the data the the end user has consented to sharing with the API consumer.
+    Otherwise, a JSON object is returned containing the data that the end user has consented to sharing with the API consumer.
     - When calling endpoint `retrieve-identifier`, the response will always contain `imei`
     - When calling endpoint `retrieve-type`, the response will always contain `tac`
     - Responses will also always contain a `lastChecked` field, indicating when the information provided was last confirmed to be correct
@@ -121,8 +121,6 @@ info:
 
     (FAQs will be added in a later version of the documentation)
 
-  contact:
-    email: sp-dvi@lists.camaraproject.org
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/documentation/API_documentation/API Readiness Checklist device-identifier.md
+++ b/documentation/API_documentation/API Readiness Checklist device-identifier.md
@@ -10,7 +10,7 @@ Checklist for device-identifier v0.2.0-alpha.1 in r2.1.
 |  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |      | Y                                                                      |
 |  5 | API documentation                            |   M   |         M         |    M    |    M   |      | Inline in OAS definition                                               |
 |  6 | User stories                                 |   O   |         O         |    O    |    M   |      | [Device Identifier User Story.md](/documentation/API_documentation/Device%20Identifier%20User%20Story.md) |
-|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |      | [DeviceIdentifier_retrieve_identifier.feature](code/Test_definitions/DeviceIdentifier_retrieve_identifier.feature) |
+|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |      | [DeviceIdentifier_retrieve_identifier.feature](/code/Test_definitions/DeviceIdentifier_retrieve_identifier.feature) |
 |  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |      | N                                                                      |
 |  9 | Test result statement                        |   O   |         O         |    O    |    M   |      | N                                                                      |
 | 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |      | Y                                                                      |

--- a/documentation/API_documentation/API Readiness Checklist device-identifier.md
+++ b/documentation/API_documentation/API Readiness Checklist device-identifier.md
@@ -4,18 +4,18 @@ Checklist for device-identifier v0.2.0-alpha.1 in r2.1.
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status  | Comments                                                               |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----------------------------------------------------------------------:|
-|  1 | API definition                               |   M   |         M         |    M    |    M   |      | [device-identifier.yaml](/code/API_definitions/device-identifier.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |      | Y 0.4.0                                                                |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |      | Y 0.2.1                                                                |
-|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |      | Y                                                                      |
-|  5 | API documentation                            |   M   |         M         |    M    |    M   |      | Inline in OAS definition                                               |
-|  6 | User stories                                 |   O   |         O         |    O    |    M   |      | [Device Identifier User Story.md](/documentation/API_documentation/Device%20Identifier%20User%20Story.md) |
-|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |      | [DeviceIdentifier_retrieve_identifier.feature](/code/Test_definitions/DeviceIdentifier_retrieve_identifier.feature) |
-|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |      | N                                                                      |
-|  9 | Test result statement                        |   O   |         O         |    O    |    M   |      | N                                                                      |
-| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |      | Y                                                                      |
-| 11 | Change log updated                           |   M   |         M         |    M    |    M   |      | [CHANGELOG.md](/CHANGELOG.md)                                          |
-| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |      | N                                                                      |
+|  1 | API definition                               |   M   |         M         |    M    |    M   |  Y   | [device-identifier.yaml](/code/API_definitions/device-identifier.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |  Y   | 0.4.0                                                                  |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |  Y   | 0.2.1                                                                  |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |  Y   |                                                                        |
+|  5 | API documentation                            |   M   |         M         |    M    |    M   |  Y   | Inline in OAS definition                                               |
+|  6 | User stories                                 |   O   |         O         |    O    |    M   |  Y   | [Device Identifier User Story.md](/documentation/API_documentation/Device%20Identifier%20User%20Story.md) |
+|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |  Y   | [DeviceIdentifier_retrieve_identifier.feature](/code/Test_definitions/DeviceIdentifier_retrieve_identifier.feature) |
+|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |  N   |                                                                        |
+|  9 | Test result statement                        |   O   |         O         |    O    |    M   |  N   |                                                                        |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |  Y   |                                                                        |
+| 11 | Change log updated                           |   M   |         M         |    M    |    M   |  Y   | [CHANGELOG.md](/CHANGELOG.md)                                          |
+| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |  N   |                                                                        |
 
 To fill the checklist:
 - in the line above the table, replace the api-name, api-version and the rx.y by their actual values for the current API version and release.

--- a/documentation/API_documentation/API Readiness Checklist device-identifier.md
+++ b/documentation/API_documentation/API Readiness Checklist device-identifier.md
@@ -24,4 +24,4 @@ To fill the checklist:
 
 Note: the checklists of a public API version and of its preceding release-candidate API version can be the same.
 
-The documentation for the content of the checklist is here: [API Readiness Checklist](https://wiki.camaraproject.org/display/CAM/API+Release+Process#APIReleaseProcess-APIreadinesschecklist).
+The documentation for the content of the checklist is here: [API Readiness Checklist](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14559630/API+Release+Process#API-readiness-checklist).

--- a/documentation/API_documentation/API Readiness Checklist device-identifier.md
+++ b/documentation/API_documentation/API Readiness Checklist device-identifier.md
@@ -1,6 +1,6 @@
 # API Readiness Checklist
 
-Checklist for device-identifier v0.2.0-alpha.1 in r2.1.
+Checklist for device-identifier v0.2.0-alpha.1 in r1.1.
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status  | Comments                                                               |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----------------------------------------------------------------------:|

--- a/documentation/API_documentation/API Readiness Checklist device-identifier.md
+++ b/documentation/API_documentation/API Readiness Checklist device-identifier.md
@@ -1,0 +1,27 @@
+# API Readiness Checklist
+
+Checklist for device-identifier v0.2.0-alpha.1 in r2.1.
+
+| Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status  | Comments                                                               |
+|----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----------------------------------------------------------------------:|
+|  1 | API definition                               |   M   |         M         |    M    |    M   |      | [device-identifier.yaml](/code/API_definitions/device-identifier.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |      | Y 0.4.0                                                                |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |      | Y 0.2.1                                                                |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |      | Y                                                                      |
+|  5 | API documentation                            |   M   |         M         |    M    |    M   |      | Inline in OAS definition                                               |
+|  6 | User stories                                 |   O   |         O         |    O    |    M   |      | [Device Identifier User Story.md](/documentation/API_documentation/Device%20Identifier%20User%20Story.md) |
+|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |      | [DeviceIdentifier_retrieve_identifier.feature](code/Test_definitions/DeviceIdentifier_retrieve_identifier.feature) |
+|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |      | N                                                                      |
+|  9 | Test result statement                        |   O   |         O         |    O    |    M   |      | N                                                                      |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |      | Y                                                                      |
+| 11 | Change log updated                           |   M   |         M         |    M    |    M   |      | [CHANGELOG.md](/CHANGELOG.md)                                          |
+| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |      | N                                                                      |
+
+To fill the checklist:
+- in the line above the table, replace the api-name, api-version and the rx.y by their actual values for the current API version and release.
+- in the Status column, put "Y" (yes) if the release asset is available or fulfilled in the current release, a "N" (no) or a "tbd". Example use of "tbd" is in case an alpha or release-candidate API version does not yet provide all mandatory assets for the release.
+- in the Comments column, provide the link to the asset once available, and any other relevant comments.
+
+Note: the checklists of a public API version and of its preceding release-candidate API version can be the same.
+
+The documentation for the content of the checklist is here: [API Readiness Checklist](https://wiki.camaraproject.org/display/CAM/API+Release+Process#APIReleaseProcess-APIreadinesschecklist).


### PR DESCRIPTION
#### What type of PR is this?
* subproject management

#### What this PR does / why we need it:
Preparation of release r1.1 for device-identifier v0.2.0-alpha.1

- [x] Update CHANGELOG.med
- [x] Update README.md
- [x] Set versions and url in device-identifier.yaml
- [x] Update API Readiness Checklists

#### Which issue(s) this PR fixes:
Fixes #71 

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Preparation of release r1.1 for device-identifier v0.2.0-alpha.1
```

#### Additional documentation 
N/A