### PR TITLE
Reset device-identifier.yaml version to "wip"

### DIFF
--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: CAMARA Mobile Device Identifier
-  version: 0.2.0-alpha.1
+  version: wip
   description: |
     # Summary
 
@@ -131,7 +131,7 @@ externalDocs:
   url: https://github.com/camaraproject/DeviceIdentifier
 
 servers:
-  - url: "{apiRoot}/device-identifier/v0.2alpha1"
+  - url: "{apiRoot}/device-identifier/vwip"
     variables:
       apiRoot:
         default: https://localhost:443


### PR DESCRIPTION
#### What type of PR is this?
* documentation

#### What this PR does / why we need it:
Following 0.2.0-alpha.1 release, API version needs to be reset to `wip`

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Reset YAML version to wip
```

#### Additional documentation 
None