### PR TITLE
Update Device object handling and description

### DIFF
--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -443,7 +443,8 @@ components:
               value:
                 status: 422
                 code: IDENTIFIER_MISMATCH
-                message: Provided device identifiers are not consistent.
+                message: Provided identifiers are not consistent.
+
             ServiceNotApplicableForDevice:
               description: Service is not available for the identified device
               value:

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -426,7 +426,8 @@ components:
                 code: UNNECESSARY_IDENTIFIER
                 message: An explicit identifier has been provided for the device when this is already identified by the access token
             Missing Identifier:
-              description: An identifier is not included in the request and the device cannot be identified from the 3-legged access token
+              description: An identifier is not included in the request and the device cannot be identified from the 2-legged access token
+
               value:
                 status: 422
                 code: MISSING_IDENTIFIER

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -262,6 +262,7 @@ paths:
 
 components:
   securitySchemes:
+    description: Common security scheme for all CAMARA APIs
     openId:
       type: openIdConnect
       openIdConnectUrl: .well-known/openid-configuration
@@ -689,13 +690,13 @@ components:
       description: Empty JSON when device is identified by access token
       value:
         {}
-        
+
     IdentifyDeviceByPhoneNumber:
       description: Identifying device by phone number
       value:
         device:
           phoneNumber: "+123456789"
-        
+
     IdentifyDeviceByIPAddress:
       description: Identifying device by IP address
       value:
@@ -703,7 +704,7 @@ components:
           ipv4Address:
             publicAddress: "84.125.93.10"
             publicPort: 59765
-            
+
     IdentifyDeviceByMultipleIdentifiers:
       description: Identifying device by multiple device identifiers
       value:

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -163,13 +163,13 @@ paths:
             schema:
               $ref: "#/components/schemas/RequestBody"
             examples:
-              IdentifyDeviceBy2LeggedToken:
-                $ref: '#/components/examples/IdentifyDeviceBy2LeggedToken'
-              IdentifyDeviceByPhoneNumber:
+              Identify Device By 3-Legged Access Token:
+                $ref: '#/components/examples/IdentifyDeviceBy3LeggedToken'
+              Identify Device By Phone Number:
                 $ref: '#/components/examples/IdentifyDeviceByPhoneNumber'
-              IdentifyDeviceByIPAddress:
+              Identify Device By IP Address:
                 $ref: '#/components/examples/IdentifyDeviceByIPAddress'
-              IdentifyDeviceByMultipleIdentifiers:
+              Identify Device By Multiple Identifiers:
                 $ref: '#/components/examples/IdentifyDeviceByMultipleIdentifiers'
 
       responses:
@@ -183,20 +183,10 @@ paths:
           $ref: '#/components/responses/403Forbidden'
         "404":
           $ref: '#/components/responses/404NotFound'
-        "406":
-          $ref: '#/components/responses/406Unacceptable'
         "422":
           $ref: '#/components/responses/422UnprocessableContent'
         "429":
           $ref: '#/components/responses/429TooManyRequests'
-        "500":
-          $ref: '#/components/responses/500InternalServerError'
-        "502":
-          $ref: '#/components/responses/502BadGateway'
-        "503":
-          $ref: '#/components/responses/503ServiceUnavailable'
-        "504":
-          $ref: '#/components/responses/504GatewayTimeout'
 
   "/retrieve-type":
     post:
@@ -225,13 +215,13 @@ paths:
             schema:
               $ref: "#/components/schemas/RequestBody"
             examples:
-              IdentifyDeviceBy2LeggedToken:
-                $ref: '#/components/examples/IdentifyDeviceBy2LeggedToken'
-              IdentifyDeviceByPhoneNumber:
+              Identify Device By 3-Legged Access Token:
+                $ref: '#/components/examples/IdentifyDeviceBy3LeggedToken'
+              Identify Device By Phone Number:
                 $ref: '#/components/examples/IdentifyDeviceByPhoneNumber'
-              IdentifyDeviceByIPAddress:
+              Identify Device By IP Address:
                 $ref: '#/components/examples/IdentifyDeviceByIPAddress'
-              IdentifyDeviceByMultipleIdentifiers:
+              Identify Device By Multiple Identifiers:
                 $ref: '#/components/examples/IdentifyDeviceByMultipleIdentifiers'
 
       responses:
@@ -245,20 +235,10 @@ paths:
           $ref: '#/components/responses/403Forbidden'
         "404":
           $ref: '#/components/responses/404NotFound'
-        "406":
-          $ref: '#/components/responses/406Unacceptable'
         "422":
           $ref: '#/components/responses/422UnprocessableContent'
         "429":
           $ref: '#/components/responses/429TooManyRequests'
-        "500":
-          $ref: '#/components/responses/500InternalServerError'
-        "502":
-          $ref: '#/components/responses/502BadGateway'
-        "503":
-          $ref: '#/components/responses/503ServiceUnavailable'
-        "504":
-          $ref: '#/components/responses/504GatewayTimeout'
 
 components:
   securitySchemes:
@@ -316,39 +296,39 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
           examples:
-            InsufficientParameters:
+            Insufficient Parameters:
               description: Sufficient parameters must be provided to allow the target UE to be identified
               value:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: "At least one of phoneNumber, networkAccessIdentifier, ipv4Address and ipv6Address must be specified"
-            InconsistentDeviceProperties:
+            Inconsistent Device Properties:
               description: Device parameters provided identify different devices
               value:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: "Multiple inconsistent device parameters specified"
-            InvalidExternalId:
+            Invalid Network Access Identifier:
               value:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: "Invalid format: networkAccessIdentifier"
-            InvalidMSISDN:
+            Invalid Phone Number:
               value:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: "Invalid format: phoneNumber"
-            InvalidIPv4:
+            Invalid IPv4 Address:
               value:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: "Invalid format: ipv4Address"
-            InvalidIPv6:
+            Invalid IPv6 Address:
               value:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: "Invalid format: ipv6Address"
-            InvalidPort:
+            Invalid Port Value:
               value:
                 status: 400
                 code: OUT_OF_RANGE
@@ -364,18 +344,18 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
           examples:
-            GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+            Unauthenticated Request:
+              description: The request cannot be authenticated, as the access token is missing, not a valid token, or has been revoked
               value:
                 status: 401
                 code: UNAUTHENTICATED
                 message: Request not authenticated due to missing, invalid, or expired credentials.
-            GENERIC_401_AUTHENTICATION_REQUIRED:
-              description: New authentication is needed, authentication is no longer valid
+            Re-Authentication Required:
+              description: A new authentication is needed, as the access token has expired
               value:
                 status: 401
                 code: AUTHENTICATION_REQUIRED
-                message: New authentication is required.
+                message: A new authentication is needed, as the access token has expired.
 
     403Forbidden:
       description: Forbidden
@@ -387,7 +367,7 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
           examples:
-            GENERIC_403_PERMISSION_DENIED:
+            Permision Denied:
               description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
               value:
                 status: 403
@@ -404,29 +384,12 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
           examples:
-            GENERIC_404_DEVICE_NOT_FOUND:
-              description: Device identifier not found
+            Device Cannot Be Found:
+              description: The provided identifier cannot be matched to a device known to the API provider
               value:
                 status: 404
                 code: IDENTIFIER_NOT_FOUND
-                message: The supplied device identifier cannot be matched to a device.
-
-    406Unacceptable:
-      description: Not Acceptable
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/X-Correlator"
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-          examples:
-            NotAcceptable:
-              description: A response format other than JSON has been requested
-              value:
-                status: 406
-                code: NOT_ACCEPTABLE
-                message: "The server cannot produce a response matching the content requested by the client through Accept-* headers"
+                message: The provided identifier cannot be matched to a device.
 
     422UnprocessableContent:
       description: Unprocessable Content
@@ -438,36 +401,36 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
           examples:
-            DeviceIdentifiersMismatch:
-              description: Inconsistency between device identifiers not identifying the same device
+            Identifiers Do Not Match:
+              description: Multiple identifiers provided which do not all identify the same device
               value:
                 status: 422
                 code: IDENTIFIER_MISMATCH
                 message: Provided identifiers are not consistent.
-
-            ServiceNotApplicableForDevice:
-              description: Service is not available for the identified device
+            Service Not Applicable For Device:
+              description: The service is not applicable for the identified device
               value:
                 status: 422
                 code: SERVICE_NOT_APPLICABLE
-                message: The service is not applicable to the identified device.
-            UnsupportedDeviceIdentifier:
-              description: Service is not available for the identified device
+                message: The service is not applicable for the identified device.
+            Unsupported Identifier:
+              description: None of the provided identifiers is supported by the implementation
               value:
                 status: 422
                 code: UNSUPPORTED_IDENTIFIER
                 message: None of the provided identifiers is supported by the implementation.
-
-            UnnecessaryDeviceIdentifier:
+            Unnecessary Identifier:
+              description: An explicit identifier has been provided for the device when this is already identified by the access token
               value:
                 status: 422
                 code: UNNECESSARY_IDENTIFIER
-                message: The device is already identified by the access token
-            MissingIdentifier:
+                message: An explicit identifier has been provided for the device when this is already identified by the access token
+            Missing Identifier:
+              description: An identifier is not included in the request and the device cannot be identified from the 3-legged access token
               value:
                 status: 422
                 code: MISSING_IDENTIFIER
-                message: The device cannot be identified
+                message: An identifier is not included in the request and the device cannot be identified from the 3-legged access token
 
     429TooManyRequests:
       description: Too Many Requests
@@ -479,68 +442,12 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
           examples:
-            TooManyRequests:
+            Too Many Requests:
               description: Access to the API has been temporarily blocked due to quota or spike arrest limits being reached
               value:
                 status: 429
                 code: TOO_MANY_REQUESTS
                 message: "Either out of resource quota or reaching rate limiting"
-
-    500InternalServerError:
-      description: Internal Server Error
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/X-Correlator"
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-          example:
-            status: 500
-            code: INTERNAL
-            message: "The service is currently not available"
-
-    502BadGateway:
-      description: Bad Gateway
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/X-Correlator"
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-          example:
-            status: 502
-            code: BAD_GATEWAY
-            message: "The service is currently not available"
-
-    503ServiceUnavailable:
-      description: Service Unavailable
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/X-Correlator"
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-          example:
-            status: 503
-            code: UNAVAILABLE
-            message: "The service is currently not available"
-
-    504GatewayTimeout:
-      description: Gateway Time-Out
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/X-Correlator"
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-          example:
-            status: 504
-            code: TIMEOUT
-            message: "The service is currently not available"
 
   schemas:
     LastChecked:
@@ -688,7 +595,7 @@ components:
       example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
 
   examples:
-    IdentifyDeviceBy2LeggedToken:
+    IdentifyDeviceBy3LeggedToken:
       description: Empty JSON when device is identified by access token
       value:
         {}

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -60,26 +60,6 @@ info:
 
     It is important to remark that in cases where personal user data is processed by the API, and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of 3-legged access tokens becomes mandatory. This measure ensures that the API remains in strict compliance with user privacy preferences and regulatory obligations, upholding the principles of transparency and user-centric data control.
 
-    ## Handling of mobile subscription information:
-
-    ### Optional mobile subscription identifiers for 3-legged tokens:
-
-    - When using a 3-legged access token, the mobile subscription identifier associated with the access token must be considered as the mobile subscription identifier for the API request. This means that no mobile subscription identifiers are required in the request, and if included it must identify the same subscription. Hence **it is recommended NOT to include it in these scenarios** to simplify the API usage and avoid additional validations.
-
-    ### Validation mechanism:
-
-    - The API server will determine the mobile subscription identifier (e.g. phone number) from the access token itself if that information is associated with it (i.e. 3-legged token).
-    - If the API request itself additionally includes one or more mobile subscription identifiers when using a 3-legged access token, the API will validate that the identifier(s) provided matches the one associated with the access token.
-    - If there is a mismatch, the API will respond with a `403 INVALID_TOKEN_CONTEXT` error, indicating that the mobile subscription information in the request does not match the token.
-
-    ### Error handling for unidentifiable devices:
-
-    - If no mobile subscription information is included in the request and the mobile subscription information cannot be derived from the 3-legged access token, the server will return a `422 UNIDENTIFIABLE_DEVICE` error.
-
-    ### Restrictions for tokens without an associated authenticated identifier:
-
-    - For scenarios which do not have a mobile subscription identifier associated to the token during the authentication flow, e.g. 2-legged access tokens, mobile subscription identifiers MUST be provided in the API request. This ensures that the mobile subscription identifier is explicit and valid for each API call made with these tokens.
-
     # API functionality
 
     The API defines two service endpoints:
@@ -116,6 +96,20 @@ info:
        "manufacturer": "Nokia"
     }
     ```
+
+    # Identifying the device from the access token
+
+    This API requires the API consumer to identify a device as the subject of the API as follows:
+    - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
+
+    - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.
+
+    This approach simplifies API usage for API consumers using a three-legged access token to invoke the API by relying on the information that is associated with the access token and was identified during the authentication process.
+
+    ## Error handling:
+    - If the subject cannot be identified from the access token and the optional `device` object is not included in the request, then the server will return an error with the `422 MISSING_IDENTIFIER` error code.
+
+    - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
 
     # Further info and support
 

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -702,7 +702,7 @@ components:
         device:
           ipv4Address:
             publicAddress: "84.125.93.10"
-            publicPort: "59765"
+            publicPort: 59765
             
     IdentifyDeviceByMultipleIdentifiers:
       description: Identifying device by multiple device identifiers
@@ -711,5 +711,5 @@ components:
           phoneNumber: "+123456789"
           ipv4Address:
             publicAddress: "84.125.93.10"
-            publicPort: "59765"
+            publicPort: 59765
           networkAccessIdentifier: "123456789@domain.com"

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -262,8 +262,8 @@ paths:
 
 components:
   securitySchemes:
-    description: Common security scheme for all CAMARA APIs
     openId:
+      description: Common security scheme for all CAMARA APIs
       type: openIdConnect
       openIdConnectUrl: .well-known/openid-configuration
 

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -52,14 +52,6 @@ info:
 
     In scenarios where a main phone number is shared between multiple devices, each of which has its own individual "secondary" phone number (e.g. connectivity plans that let you share your airtime and data allowances with a smartwatch or eSIM-enabled tablet), the phone number passed by the API consumer will be treated as the secondary phone number, and hence the identifier returned will be that of the single device associated with that phone number (e.g. smartphone, smartwatch, or eSIM-enabled tablet). In such scenarios, the "primary" device is usually allocated the same main and secondary phone numbers, and hence providing the main phone number to the API will return the identity of the primary device (usually the smartphone) and not any associated devices.
 
-    ### Authorization and authentication
-
-    The "Camara Security and Interoperability Profile" provides details on how a client requests an access token. Please refer to Identify and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the Profile.
-
-    Which specific authorization flows are to be used will be determined during onboarding process, happening between the API Client and the Telco Operator exposing the API, taking into account the declared purpose for accessing the API, while also being subject to the prevailing legal framework dictated by local legislation.
-
-    It is important to remark that in cases where personal user data is processed by the API, and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of 3-legged access tokens becomes mandatory. This measure ensures that the API remains in strict compliance with user privacy preferences and regulatory obligations, upholding the principles of transparency and user-centric data control.
-
     # API functionality
 
     The API defines two service endpoints:
@@ -97,7 +89,17 @@ info:
     }
     ```
 
-    # Identifying the device from the access token
+    # Further info and support
+
+    ## Authorization and authentication
+
+    The "Camara Security and Interoperability Profile" provides details on how a client requests an access token. Please refer to Identify and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the Profile.
+
+    Which specific authorization flows are to be used will be determined during onboarding process, happening between the API Client and the Telco Operator exposing the API, taking into account the declared purpose for accessing the API, while also being subject to the prevailing legal framework dictated by local legislation.
+
+    It is important to remark that in cases where personal user data is processed by the API, and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of 3-legged access tokens becomes mandatory. This measure ensures that the API remains in strict compliance with user privacy preferences and regulatory obligations, upholding the principles of transparency and user-centric data control.
+
+    ## Identifying the device from the access token
 
     This API requires the API consumer to identify a device as the subject of the API as follows:
     - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
@@ -110,8 +112,6 @@ info:
     - If the subject cannot be identified from the access token and the optional `device` object is not included in the request, then the server will return an error with the `422 MISSING_IDENTIFIER` error code.
 
     - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
-
-    # Further info and support
 
     (FAQs will be added in a later version of the documentation)
 

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -162,6 +162,15 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/RequestBody"
+            examples:
+              IdentifyDeviceBy2LeggedToken:
+                $ref: '#/components/examples/IdentifyDeviceBy2LeggedToken'
+              IdentifyDeviceByPhoneNumber:
+                $ref: '#/components/examples/IdentifyDeviceByPhoneNumber'
+              IdentifyDeviceByIPAddress:
+                $ref: '#/components/examples/IdentifyDeviceByIPAddress'
+              IdentifyDeviceByMultipleIdentifiers:
+                $ref: '#/components/examples/IdentifyDeviceByMultipleIdentifiers'
 
       responses:
         "200":
@@ -215,6 +224,15 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/RequestBody"
+            examples:
+              IdentifyDeviceBy2LeggedToken:
+                $ref: '#/components/examples/IdentifyDeviceBy2LeggedToken'
+              IdentifyDeviceByPhoneNumber:
+                $ref: '#/components/examples/IdentifyDeviceByPhoneNumber'
+              IdentifyDeviceByIPAddress:
+                $ref: '#/components/examples/IdentifyDeviceByIPAddress'
+              IdentifyDeviceByMultipleIdentifiers:
+                $ref: '#/components/examples/IdentifyDeviceByMultipleIdentifiers'
 
       responses:
         "200":
@@ -665,3 +683,33 @@ components:
       type: string
       format: ipv6
       example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+
+  examples:
+    IdentifyDeviceBy2LeggedToken:
+      description: Empty JSON when device is identified by access token
+      value:
+        {}
+        
+    IdentifyDeviceByPhoneNumber:
+      description: Identifying device by phone number
+      value:
+        device:
+          phoneNumber: "+123456789"
+        
+    IdentifyDeviceByIPAddress:
+      description: Identifying device by IP address
+      value:
+        device:
+          ipv4Address:
+            publicAddress: "84.125.93.10"
+            publicPort: "59765"
+            
+    IdentifyDeviceByMultipleIdentifiers:
+      description: Identifying device by multiple device identifiers
+      value:
+        device:
+          phoneNumber: "+123456789"
+          ipv4Address:
+            publicAddress: "84.125.93.10"
+            publicPort: "59765"
+          networkAccessIdentifier: "123456789@domain.com"

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -157,11 +157,11 @@ paths:
 
       requestBody:
         description: Parameters to create a new session
-        required: false
+        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Device"
+              $ref: "#/components/schemas/RequestBody"
 
       responses:
         "200":
@@ -210,11 +210,11 @@ paths:
 
       requestBody:
         description: Parameters to create a new session
-        required: false
+        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Device"
+              $ref: "#/components/schemas/RequestBody"
 
       responses:
         "200":
@@ -641,6 +641,13 @@ components:
       type: integer
       minimum: 1024
       maximum: 65535
+
+    RequestBody:
+      description: Common request body to allow optional Device object to be passed
+      type: object
+      properties:
+        device:
+          $ref: "#/components/schemas/Device"
 
     SingleIpv4Addr:
       description: A single IPv4 address with no subnet mask

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -108,7 +108,7 @@ info:
 
     This approach simplifies API usage for API consumers using a three-legged access token to invoke the API by relying on the information that is associated with the access token and was identified during the authentication process.
 
-    ## Error handling:
+    ### Error handling:
     - If the subject cannot be identified from the access token and the optional `device` object is not included in the request, then the server will return an error with the `422 MISSING_IDENTIFIER` error code.
 
     - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -119,7 +119,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  x-camara-commonalities: 0.4.0
+  x-camara-commonalities: 0.5
 
 externalDocs:
   description: Product documentation at CAMARA

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -374,12 +374,6 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_INVALID_TOKEN_CONTEXT:
-              description: Reflect some inconsistency between information in some field of the API and the related OAuth2 Token
-              value:
-                status: 403
-                code: INVALID_TOKEN_CONTEXT
-                message: "{{field}} is not consistent with access token."
 
     404NotFound:
       description: Not found
@@ -391,18 +385,12 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
           examples:
-            GENERIC_404_NOT_FOUND:
-              description: Resource is not found
-              value:
-                status: 404
-                code: NOT_FOUND
-                message: The specified resource is not found.
             GENERIC_404_DEVICE_NOT_FOUND:
               description: Device identifier not found
               value:
                 status: 404
-                code: DEVICE_NOT_FOUND
-                message: Device identifier not found.
+                code: IDENTIFIER_NOT_FOUND
+                message: The supplied device identifier cannot be matched to a device.
 
     406Unacceptable:
       description: Not Acceptable
@@ -431,18 +419,34 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
           examples:
-            GENERIC_422_DEVICE_IDENTIFIERS_MISMATCH:
-              description: Inconsistency between device identifiers not pointing to the same device
+            DeviceIdentifiersMismatch:
+              description: Inconsistency between device identifiers not identifying the same device
               value:
                 status: 422
-                code: DEVICE_IDENTIFIERS_MISMATCH
+                code: IDENTIFIER_MISMATCH
                 message: Provided device identifiers are not consistent.
-            GENERIC_422_DEVICE_NOT_APPLICABLE:
-              description: Service is not available for the provided device
+            ServiceNotApplicableForDevice:
+              description: Service is not available for the identified device
               value:
                 status: 422
-                code: DEVICE_NOT_APPLICABLE
-                message: The service is not available for the provided device.
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not applicable to the identified device.
+            UnsupportedDeviceIdentifier:
+              description: Service is not available for the identified device
+              value:
+                status: 422
+                code: UNSUPPORTED_IDENTIFIER
+                message: None of the provided device identifiers is supported by the implementation.
+            UnnecessaryDeviceIdentifier:
+              value:
+                status: 422
+                code: UNNECESSARY_IDENTIFIER
+                message: The device is already identified by the access token
+            MissingIdentifier:
+              value:
+                status: 422
+                code: MISSING_IDENTIFIER
+                message: The device cannot be identified
 
     429TooManyRequests:
       description: Too Many Requests

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -455,7 +455,8 @@ components:
               value:
                 status: 422
                 code: UNSUPPORTED_IDENTIFIER
-                message: None of the provided device identifiers is supported by the implementation.
+                message: None of the provided identifiers is supported by the implementation.
+
             UnnecessaryDeviceIdentifier:
               value:
                 status: 422

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -431,7 +431,8 @@ components:
               value:
                 status: 422
                 code: MISSING_IDENTIFIER
-                message: An identifier is not included in the request and the device cannot be identified from the 3-legged access token
+                message: An identifier is not included in the request and the device cannot be identified from the 2-legged access token
+
 
     429TooManyRequests:
       description: Too Many Requests


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature
* documentation

#### What this PR does / why we need it:
Other APIs passing a Device object do this by passing a separate parameter named `device`, even if that is the only object passed in the request. This PR:
- Updates the Device Identifier API to use this pattern
- Updates documentation on identifying the device from the access token following the current agreement in Commonalities
- Updates the API error responses following the current agreement in Commonalities
- Removes 406, and 5XX errors from the OAS definition, as these errors do not need to be explicitly documented and are not relevant to the API use case

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # N/A

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Update Device object handling and description
 - Remove errors not required to be documented
 - Update examples for remaining errors
```

#### Additional documentation 
None