### PR TITLE
Remove multi-sim text

### DIFF
--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -50,8 +50,6 @@ info:
       - IPv6 address
       - IPv4 address
 
-    In scenarios where a main phone number is shared between multiple devices, each of which has its own individual "secondary" phone number (e.g. connectivity plans that let you share your airtime and data allowances with a smartwatch or eSIM-enabled tablet), the phone number passed by the API consumer will be treated as the secondary phone number, and hence the identifier returned will be that of the single device associated with that phone number (e.g. smartphone, smartwatch, or eSIM-enabled tablet). In such scenarios, the "primary" device is usually allocated the same main and secondary phone numbers, and hence providing the main phone number to the API will return the identity of the primary device (usually the smartphone) and not any associated devices.
-
     ### Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details on how a client requests an access token. Please refer to Identify and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the Profile.


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* cleanup
* documentation


#### What this PR does / why we need it:
Multi-SIM support is not well-understood and should be "solved" for all CAMARA APIs.
Multi-SIM support was discussed in several CAMARA API subprojects without solution.
For interoperability reasons API providers should handle the Multi-SIM case in the same manner.

#### Additional documentation 

[Support of Multi-SIM lines in CAMARA APIs #302](https://github.com/camaraproject/Commonalities/issues/302)
