### PR TITLE
Remove AUTHENTICATION_REQUIRED error code

### DIFF
--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -81,7 +81,7 @@ info:
 
     Errors may be returned for the following reasons. Note that this list is not exhaustive.
 
-    `401 UNAUTHENTICATED`or `401 AUTHENTICATION_REQUIRED`:
+    `401 UNAUTHENTICATED`:
     - The access token is not a valid access token for the API provider
     - The access token was valid but has now expired
 
@@ -402,20 +402,13 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
-                      - AUTHENTICATION_REQUIRED
           examples:
             Unauthenticated Request:
-              description: The request cannot be authenticated, as the access token is missing, not a valid token, or has been revoked
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
-            Re-Authentication Required:
-              description: A new authentication is needed, as the access token has expired
-              value:
-                status: 401
-                code: AUTHENTICATION_REQUIRED
-                message: A new authentication is needed, as the access token has expired.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
 
     403Forbidden:
       description: Forbidden

--- a/code/Test_definitions/device-identifier-retrieveIdentifier.feature
+++ b/code/Test_definitions/device-identifier-retrieveIdentifier.feature
@@ -255,7 +255,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
       And the response header "x-correlator" has same value as the request header "x-correlator"
       And the response header "Content-Type" is "application/json"
       And the response property "$.status" is 401
-      And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+      And the response property "$.code" is "UNAUTHENTICATED"
       And the response property "$.message" contains a user friendly text
 
   @DeviceIdentifier_retrieveIdentifier_401.3_invalid_access_token

--- a/code/Test_definitions/device-identifier-retrieveType.feature
+++ b/code/Test_definitions/device-identifier-retrieveType.feature
@@ -241,7 +241,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
       And the response header "x-correlator" has same value as the request header "x-correlator"
       And the response header "Content-Type" is "application/json"
       And the response property "$.status" is 401
-      And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+      And the response property "$.code" is "UNAUTHENTICATED"
       And the response property "$.message" contains a user friendly text
 
   @DeviceIdentifier_retrieveType_401.3_invalid_access_token


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities pre-release [r3.1](https://github.com/camaraproject/Commonalities/releases/tag/r3.1) removes the `AUTHENTICATION_REQUIRED` error code, leaving `UNAUTHENTICATED` as the only valid error code when the HTTP status code is 401. This PR removes all instances of `AUTHENTICATION_REQUIRED`.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:
This is not a breaking change

#### Changelog input
```
 release-note
 - Remove AUTHENTICATION_REQUIRED error code
```

#### Additional documentation 
None