### PR TITLE
Remove IDENTIFIER_MISMATCH error and include optional device property in 200 response

### DIFF
--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -706,6 +706,7 @@ components:
       allOf:
         - $ref: "#/components/schemas/Device"
         - maxProperties: 1
+        - example: { "phoneNumber": "+123456789" }
 
     DeviceIpv4Addr:
       type: object

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -371,6 +371,17 @@ components:
               - $ref: "#/components/schemas/CommonResponseBody"
               - $ref: "#/components/schemas/DeviceIdentifier"
               - $ref: "#/components/schemas/DeviceType"
+          examples:
+            Successful Response:
+              description: Device identifier has been successfully retrieved
+              value:
+                device: {"phoneNumber": "+123456789"},
+                lastChecked: "2024-02-20T10:41:38.657Z",
+                imeisv: "49015420323751800",
+                imei: "4901542032375181",
+                tac: "49015420",
+                model: "3110",
+                manufacturer: "Nokia"
 
     200RetrieveType:
       description: An device identifier has been found for the specified subscriber

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -701,6 +701,7 @@ components:
 
         If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
 
+      example: "phoneNumber": "+123456789"
       allOf:
         - $ref: "#/components/schemas/Device"
         - maxProperties: 1

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -77,6 +77,7 @@ info:
     An example of a JSON response object is as follows:
     ```
     {
+       "phoneNumber": "+123456789",
        "lastChecked": "2024-02-20T10:41:38.657Z",
        "imeisv": "49015420323751800",
        "imei": "4901542032375181",
@@ -106,9 +107,6 @@ info:
     `403 PERMISSION_DENIED`:
     - The access token does not have the required scope for the endpoint being called
     - The end user has not consented to the API consumer getting access to the device identifier information (2-legged access token only)
-
-    `422 IDENTIFIER_MISMATCH`:
-    - Multiple parameters have been provided in the `device` object, and these do not identify the same device
 
     `422 SERVICE_NOT_APPLICABLE`:
     - A device identifier cannot be provided for the identified device. For example, the phone number might identify a landline.
@@ -370,6 +368,7 @@ components:
               - lastChecked
               - imei
             allOf:
+              - $ref: "#/components/schema/DeviceResponse"
               - $ref: "#/components/schemas/LastChecked"
               - $ref: "#/components/schemas/DeviceIdentifier"
               - $ref: "#/components/schemas/DeviceType"
@@ -386,6 +385,7 @@ components:
               - lastChecked
               - tac
             allOf:
+              - $ref: "#/components/schema/DeviceResponse"
               - $ref: "#/components/schemas/LastChecked"
               - $ref: "#/components/schemas/DeviceType"
 
@@ -401,6 +401,7 @@ components:
               - lastChecked
               - ppid
             allOf:
+              - $ref: "#/components/schema/DeviceResponse"
               - $ref: "#/components/schemas/LastChecked"
               - $ref: "#/components/schemas/DevicePPID"
 
@@ -557,18 +558,11 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
           examples:
-            Identifiers Do Not Match:
-              description: Multiple identifiers provided which do not all identify the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             Service Not Applicable For Device:
               description: The service is not applicable for the identified device
               value:
@@ -700,6 +694,16 @@ components:
         ipv6Address:
           $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
+
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
 
     DeviceIpv4Addr:
       type: object

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -624,7 +624,7 @@ components:
       properties:
         device:
           description: The device subscription identifier that was used to identify the device whose identifier is being returned
-          allOF:
+          allOf:
             - $ref: "#/components/schemas/DeviceResponse"
         lastChecked:
           description: Date and time that the information was last confirmed by the mobile operator to be correct

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -375,7 +375,7 @@ components:
             Successful Response:
               description: Device identifier has been successfully retrieved
               value:
-                device: {"phoneNumber": "+123456789"},
+                device: '{"phoneNumber": "+123456789"}',
                 lastChecked: "2024-02-20T10:41:38.657Z",
                 imeisv: "49015420323751800",
                 imei: "4901542032375181",

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -77,7 +77,7 @@ info:
     An example of a JSON response object is as follows:
     ```
     {
-       "phoneNumber": "+123456789",
+       "device": {"phoneNumber": "+123456789"},
        "lastChecked": "2024-02-20T10:41:38.657Z",
        "imeisv": "49015420323751800",
        "imei": "4901542032375181",

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -368,8 +368,7 @@ components:
               - lastChecked
               - imei
             allOf:
-              - $ref: "#/components/schemas/DeviceResponse"
-              - $ref: "#/components/schemas/LastChecked"
+              - $ref: "#/components/schemas/CommonResponseBody"
               - $ref: "#/components/schemas/DeviceIdentifier"
               - $ref: "#/components/schemas/DeviceType"
 
@@ -385,8 +384,7 @@ components:
               - lastChecked
               - tac
             allOf:
-              - $ref: "#/components/schemas/DeviceResponse"
-              - $ref: "#/components/schemas/LastChecked"
+              - $ref: "#/components/schemas/CommonResponseBody"
               - $ref: "#/components/schemas/DeviceType"
 
     200RetrievePPID:
@@ -401,8 +399,7 @@ components:
               - lastChecked
               - ppid
             allOf:
-              - $ref: "#/components/schemas/DeviceResponse"
-              - $ref: "#/components/schemas/LastChecked"
+              - $ref: "#/components/schemas/CommonResponseBody"
               - $ref: "#/components/schemas/DevicePPID"
 
     400BadRequest:
@@ -621,10 +618,15 @@ components:
                 code: QUOTA_EXCEEDED
                 message: Out of resource quota
   schemas:
-    LastChecked:
+    CommonResponseBody:
       description: |
-        The last time that the information returned (e.g. IMEI) was confirmed to be correct by the mobile operator for the provided identifier (e.g. phone number)
+        Common parameters to be included in all responses
       properties:
+        device:
+          description: The device subscription identifier that was used to identify the device whose identifier is being returned
+          example: "phoneNumber": "+123456789"
+          allOF:
+            - $ref: "#/components/schemas/DeviceResponse"
         lastChecked:
           description: Date and time that the information was last confirmed by the mobile operator to be correct
           type: string
@@ -701,7 +703,6 @@ components:
 
         If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
 
-      example: "phoneNumber": "+123456789"
       allOf:
         - $ref: "#/components/schemas/Device"
         - maxProperties: 1

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -624,7 +624,6 @@ components:
       properties:
         device:
           description: The device subscription identifier that was used to identify the device whose identifier is being returned
-          example: {"phoneNumber": "+123456789"}
           allOF:
             - $ref: "#/components/schemas/DeviceResponse"
         lastChecked:

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -624,7 +624,7 @@ components:
       properties:
         device:
           description: The device subscription identifier that was used to identify the device whose identifier is being returned
-          example: "phoneNumber": "+123456789"
+          example: {"phoneNumber": "+123456789"}
           allOF:
             - $ref: "#/components/schemas/DeviceResponse"
         lastChecked:

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -626,6 +626,7 @@ components:
           description: The device subscription identifier that was used to identify the device whose identifier is being returned
           allOf:
             - $ref: "#/components/schemas/DeviceResponse"
+            - example: { "phoneNumber": "+123456789" }
         lastChecked:
           description: Date and time that the information was last confirmed by the mobile operator to be correct
           type: string

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -368,7 +368,7 @@ components:
               - lastChecked
               - imei
             allOf:
-              - $ref: "#/components/schema/DeviceResponse"
+              - $ref: "#/components/schemas/DeviceResponse"
               - $ref: "#/components/schemas/LastChecked"
               - $ref: "#/components/schemas/DeviceIdentifier"
               - $ref: "#/components/schemas/DeviceType"
@@ -385,7 +385,7 @@ components:
               - lastChecked
               - tac
             allOf:
-              - $ref: "#/components/schema/DeviceResponse"
+              - $ref: "#/components/schemas/DeviceResponse"
               - $ref: "#/components/schemas/LastChecked"
               - $ref: "#/components/schemas/DeviceType"
 
@@ -401,7 +401,7 @@ components:
               - lastChecked
               - ppid
             allOf:
-              - $ref: "#/components/schema/DeviceResponse"
+              - $ref: "#/components/schemas/DeviceResponse"
               - $ref: "#/components/schemas/LastChecked"
               - $ref: "#/components/schemas/DevicePPID"
 

--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -375,12 +375,12 @@ components:
             Successful Response:
               description: Device identifier has been successfully retrieved
               value:
-                device: '{"phoneNumber": "+123456789"}',
-                lastChecked: "2024-02-20T10:41:38.657Z",
-                imeisv: "49015420323751800",
-                imei: "4901542032375181",
-                tac: "49015420",
-                model: "3110",
+                device: {"phoneNumber": "+123456789"}
+                lastChecked: "2024-02-20T10:41:38.657Z"
+                imeisv: "49015420323751800"
+                imei: "4901542032375181"
+                tac: "49015420"
+                model: "3110"
                 manufacturer: "Nokia"
 
     200RetrieveType:
@@ -397,6 +397,15 @@ components:
             allOf:
               - $ref: "#/components/schemas/CommonResponseBody"
               - $ref: "#/components/schemas/DeviceType"
+          examples:
+            Successful Response:
+              description: Device type has been successfully retrieved
+              value:
+                device: {"phoneNumber": "+123456789"}
+                lastChecked: "2024-02-20T10:41:38.657Z"
+                tac: "49015420"
+                model: "3110"
+                manufacturer: "Nokia"
 
     200RetrievePPID:
       description: A pseudonymous device identifier has been found for the specified mobile subscriber
@@ -412,6 +421,13 @@ components:
             allOf:
               - $ref: "#/components/schemas/CommonResponseBody"
               - $ref: "#/components/schemas/DevicePPID"
+          examples:
+            Successful Response:
+              description: Device PPID has been successfully retrieved
+              value:
+                device: {"phoneNumber": "+123456789"}
+                lastChecked: "2024-02-20T10:41:38.657Z"
+                ppid: "b083f65ccdad365d7489fff24b6d5074b30c12b6d81db3404d25964ffd908813"
 
     400BadRequest:
       description: Bad Request
@@ -634,7 +650,7 @@ components:
         Common parameters to be included in all responses
       properties:
         device:
-          description: The device subscription identifier that was used to identify the device whose identifier is being returned
+          description: The device subscription identifier that was used to identify the device whose identifier is being returned. If this property is not present, then the device subscription identifier specified in the request was used.
           allOf:
             - $ref: "#/components/schemas/DeviceResponse"
             - example: { "phoneNumber": "+123456789" }


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
Commonalities has removed the `IDENTIFIER_MISMATCH` error code for Fall25.
This PR:
- Removes the `422 IDENTIFIER_MISMATCH` error code and an option
- Includes an optional `device` property of type `DeviceResponse` in a successful response
- Adds full examples for 200 responses
- Updates documentation

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #118 

#### Special notes for reviewers:
This is not a breaking change for the API consumer

#### Changelog input

```
 release-note
 - Remove IDENTIFIER_MISMATCH error and include optional device property in 200 response
```

#### Additional documentation 
None