### PR TITLE
Simplify OAS definition by defining `x-correlator` parameter

### DIFF
--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -194,14 +194,8 @@ paths:
       security:
         - openId:
             - device-identifier:retrieve-identifier
-
       parameters:
-        - in: header
-          name: x-correlator
-          description: Correlation id for the different services
-          required: false
-          schema:
-            $ref: "#/components/schemas/XCorrelator"
+        - $ref: "#/components/parameters/x-correlator"
 
       requestBody:
         description: Parameters to create a new session
@@ -246,14 +240,8 @@ paths:
       security:
         - openId:
             - device-identifier:retrieve-type
-
       parameters:
-        - in: header
-          name: x-correlator
-          description: Correlation id for the different services
-          required: false
-          schema:
-            $ref: "#/components/schemas/XCorrelator"
+        - $ref: "#/components/parameters/x-correlator"
 
       requestBody:
         description: Parameters to create a new session
@@ -298,14 +286,8 @@ paths:
       security:
         - openId:
             - device-identifier:retrieve-ppid
-
       parameters:
-        - in: header
-          name: x-correlator
-          description: Correlation id for the different services
-          required: false
-          schema:
-            $ref: "#/components/schemas/XCorrelator"
+        - $ref: "#/components/parameters/x-correlator"
 
       requestBody:
         description: Parameters to identify the mobile subscription when a 2-legged access token is being used
@@ -346,6 +328,14 @@ components:
       description: Common security scheme for all CAMARA APIs
       type: openIdConnect
       openIdConnectUrl: .well-known/openid-configuration
+
+  parameters:
+    x-correlator:
+      name: x-correlator
+      in: header
+      description: Correlation id for the different services
+      schema:
+        $ref: "#/components/schemas/XCorrelator"
 
   headers:
     X-Correlator:


### PR DESCRIPTION
#### What type of PR is this?
* cleanup

#### What this PR does / why we need it:
Defines a common `x-correlator` parameter schema which can be referenced by all endpoints

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # N/A

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Simplify OAS definition by defining `x-correlator` parameter
```

#### Additional documentation 
None