### PR TITLE
Feature file fixes

### DIFF
--- a/code/Test_definitions/device-identifier-retrieveIdentifier.feature
+++ b/code/Test_definitions/device-identifier-retrieveIdentifier.feature
@@ -33,7 +33,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the resource "/device-identifier/vwip/retrieve-identifier"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
-    And the header "x-correlator" is set to a UUID value
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is compliant with the RequestBody schema defined by "/components/schemas/RequestBody"
 
   # Success scenarios
@@ -215,11 +215,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
       And the response property "$.message" contains a user friendly text
 
       Examples:
-          | device_identifier          | oas_spec_schema                             |
-          | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-          | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
-          | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
-          | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
+          | device_identifier                | oas_spec_schema                             |
+          | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
+          | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+          | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
+          | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
   # The maximum is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction, and both could be accepted
   @DeviceIdentifier_retrieveIdentifier_400.5_out_of_range_port

--- a/code/Test_definitions/device-identifier-retrievePPID.feature
+++ b/code/Test_definitions/device-identifier-retrievePPID.feature
@@ -35,7 +35,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the resource "/device-identifier/vwip/retrieve-ppid"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
-    And the header "x-correlator" is set to a UUID value
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is compliant with the RequestBody schema defined by "/components/schemas/RequestBody"
 
   # Success scenarios
@@ -189,11 +189,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
       And the response property "$.message" contains a user friendly text
 
       Examples:
-          | device_identifier          | oas_spec_schema                             |
-          | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-          | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
-          | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
-          | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
+          | device_identifier                | oas_spec_schema                             |
+          | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
+          | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+          | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
+          | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
   # The maximum is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction, and both could be accepted
   @DeviceIdentifier_retrievePPID_400.5_out_of_range_port

--- a/code/Test_definitions/device-identifier-retrieveType.feature
+++ b/code/Test_definitions/device-identifier-retrieveType.feature
@@ -33,7 +33,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the resource "/device-identifier/vwip/retrieve-type"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
-    And the header "x-correlator" is set to a UUID value
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is compliant with the RequestBody schema defined by "/components/schemas/RequestBody"
 
   # Success scenarios
@@ -201,11 +201,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
       And the response property "$.message" contains a user friendly text
 
       Examples:
-          | device_identifier          | oas_spec_schema                             |
-          | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-          | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
-          | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
-          | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
+          | device_identifier                | oas_spec_schema                             |
+          | $.device.phoneNumber             | /components/schemas/PhoneNumber             |
+          | $.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+          | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
+          | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
   # The maximum is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction, and both could be accepted
   @DeviceIdentifier_retrieveType_400.5_out_of_range_port


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Makes the following changes to the feature files:
- Generalise `x-correlator` requirement to be aby valid string compliant with the schema, and not just a UUID
- Fix typos `NetworkIdentifier` -> `NetworkAccessIdentifier`

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # N/A

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Feature file fixes
```

#### Additional documentation 
None