### PR TITLE
Update release-plan.yaml for r3.2 (0.4.0-rc.1)

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,11 +16,11 @@ repository:
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r3.1
+  target_release_tag: r3.2
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-alpha
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -34,7 +34,7 @@ dependencies:
 apis:
   - api_name: device-identifier
     target_api_version: 0.4.0
-    target_api_status: alpha
+    target_api_status: rc
     main_contacts:
       - eric-murray
       - Kevsy


### PR DESCRIPTION
#### What type of PR is this?
* subproject management

#### What this PR does / why we need it:
r3.1 (0.4.0-alpha.1) is now published. Updating release plan to announce intention to publish a release candidate for 0.4.0.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Update release-plan.yaml for r3.2 (0.4.0-rc.1)
```

#### Additional documentation 
None