### PR TITLE
[Fixed] Fix ipv4Address typo in feature files

### DIFF
--- a/code/Test_definitions/device-identifier-retrieveIdentifier.feature
+++ b/code/Test_definitions/device-identifier-retrieveIdentifier.feature
@@ -77,8 +77,8 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 identifying device by IPv4 address
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
     And no subject is identified by the access token
-    And request property "$.device.ipv4address.publicAddress" is set to PUBLICIPV4ADDRESS
-    And request property "$.device.ipv4address.publicPort" is set to PUBLICPORT
+    And request property "$.device.ipv4Address.publicAddress" is set to PUBLICIPV4ADDRESS
+    And request property "$.device.ipv4Address.publicPort" is set to PUBLICPORT
     When the HTTPS "POST" request is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveIdentifier schema at "/components/schemas/200RetrieveIdentifier"

--- a/code/Test_definitions/device-identifier-retrievePPID.feature
+++ b/code/Test_definitions/device-identifier-retrievePPID.feature
@@ -71,8 +71,8 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 identifying device by IPv4 address
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
     And no subject is identified by the access token
-    And request property "$.device.ipv4address.publicAddress" is set to PUBLICIPV4ADDRESS
-    And request property "$.device.ipv4address.publicPort" is set to PUBLICPORT
+    And request property "$.device.ipv4Address.publicAddress" is set to PUBLICIPV4ADDRESS
+    And request property "$.device.ipv4Address.publicPort" is set to PUBLICPORT
     When the HTTPS "POST" request is sent
     Then the response status code is 200
     And the response body complies with the 200RetrievePPID schema at "/components/schemas/200RetrievePPID"

--- a/code/Test_definitions/device-identifier-retrieveType.feature
+++ b/code/Test_definitions/device-identifier-retrieveType.feature
@@ -73,8 +73,8 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 identifying device by IPv4 address
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
     And no subject is identified by the access token
-    And request property "$.device.ipv4address.publicAddress" is set to PUBLICIPV4ADDRESS
-    And request property "$.device.ipv4address.publicPort" is set to PUBLICPORT
+    And request property "$.device.ipv4Address.publicAddress" is set to PUBLICIPV4ADDRESS
+    And request property "$.device.ipv4Address.publicPort" is set to PUBLICPORT
     When the HTTPS "POST" request is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveType schema at "/components/schemas/200RetrieveType"


### PR DESCRIPTION
#### What type of PR is this?
* correction
* tests

#### What this PR does / why we need it:
Fixes a typo in the `ipv4Address` property used in feature file tests

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #181 

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - [Fixed] Fix typo in ipv4Address property in feature files
```

#### Additional documentation 
None