### PR TITLE
[Changed] Make lastChecked property nullable and add examples

### DIFF
--- a/code/API_definitions/device-identifier.yaml
+++ b/code/API_definitions/device-identifier.yaml
@@ -408,6 +408,15 @@ components:
                 tac: "49015420"
                 model: "3110"
                 manufacturer: "Nokia"
+            Successful Identifier Retrieval With Null lastChecked Field:
+              description: Device identifier has been successfully retrieved but the API provider has no information on when that information was last confirmed to be correct
+              value:
+                lastChecked: null
+                imeisv: "4901542032375180"
+                imei: "490154203237518"
+                tac: "49015420"
+                model: "3110"
+                manufacturer: "Nokia"
             Successful Identifier Retrieval With Device Disambiguation:
               description: Device identifier has been successfully retrieved when a 2-legged access token and multiple device subscription identifiers were provided
               value:
@@ -442,6 +451,13 @@ components:
                 tac: "49015420"
                 model: "3110"
                 manufacturer: "Nokia"
+            Successful Type Retrieval With Null lastChecked Field:
+              description: Device identifier has been successfully retrieved but the API provider has no information on when that information was last confirmed to be correct
+              value:
+                lastChecked: null
+                tac: "49015420"
+                model: "3110"
+                manufacturer: "Nokia"
             Successful Type Retrieval With Device Disambiguation:
               description: Device type has been successfully retrieved when a 2-legged access token and multiple device subscription identifiers were provided
               value:
@@ -471,6 +487,11 @@ components:
               description: Device PPID has been successfully retrieved when the device subcsription was identified by a 3-legged access token or single device subscription identifier
               value:
                 lastChecked: "2024-02-20T10:41:38.657Z"
+                ppid: "b083f65ccdad365d7489fff24b6d5074b30c12b6d81db3404d25964ffd908813"
+            Successful PPID Retrieval With Null lastChecked Field:
+              description: Device identifier has been successfully retrieved but the API provider has no information on when that information was last confirmed to be correct
+              value:
+                lastChecked: null
                 ppid: "b083f65ccdad365d7489fff24b6d5074b30c12b6d81db3404d25964ffd908813"
             Successful PPID Retrieval With Device Disambiguation:
               description: Device PPID has been successfully retrieved when a 2-legged access token and multiple device subscription identifiers were provided
@@ -502,6 +523,11 @@ components:
               description: Device identifier match has been successfully determined when the device subscription was identified by a 3-legged access token or single device subscription identifier
               value:
                 lastChecked: "2024-02-20T10:41:38.657Z"
+                match: true
+            Successful Match With Null lastChecked Field:
+              description: Device identifier match has been successfully determined but the API provider has no information on when this information was last confirmed to be correct
+              value:
+                lastChecked: null
                 match: true
             Successful Non-Match:
               description: Device identifier does not match when the device subscription was identified by a 3-legged access token or single device subscription identifier
@@ -648,8 +674,11 @@ components:
         lastChecked:
           description: |
             Date and time that the information was last confirmed by the mobile operator to be correct. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-          allOf:
-            - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
+          type: string
+          format: date-time
+          maxLength: 64
+          nullable: true
+          example: "2018-04-05T17:31:00Z"
 
     DeviceIdentifier:
       description: |

--- a/code/Test_definitions/device-identifier-matchIdentifier.feature
+++ b/code/Test_definitions/device-identifier-matchIdentifier.feature
@@ -52,7 +52,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.match" exists and is true
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imei" does not exist
     And the response property "$.imeisv" does not exist
     And the response property "$.tac" does not exist
@@ -78,7 +78,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.match" exists and is true
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imei" does not exist
     And the response property "$.imeisv" does not exist
     And the response property "$.tac" does not exist
@@ -98,7 +98,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.match" exists and is false
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imei" does not exist
     And the response property "$.imeisv" does not exist
     And the response property "$.tac" does not exist
@@ -119,7 +119,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.match" exists and is true
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imei" does not exist
     And the response property "$.imeisv" does not exist
     And the response property "$.tac" does not exist
@@ -140,7 +140,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.match" exists and is false
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imei" does not exist
     And the response property "$.imeisv" does not exist
     And the response property "$.tac" does not exist
@@ -162,7 +162,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.match" exists and is true
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imei" does not exist
     And the response property "$.imeisv" does not exist
     And the response property "$.tac" does not exist
@@ -184,7 +184,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.match" exists and is false
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imei" does not exist
     And the response property "$.imeisv" does not exist
     And the response property "$.tac" does not exist
@@ -204,7 +204,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.match" exists and is false
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imei" does not exist
     And the response property "$.imeisv" does not exist
     And the response property "$.tac" does not exist
@@ -230,7 +230,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.match" exists and is true
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imei" does not exist
     And the response property "$.imeisv" does not exist
     And the response property "$.tac" does not exist
@@ -256,7 +256,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.match" exists and is true
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imei" does not exist
     And the response property "$.imeisv" does not exist
     And the response property "$.tac" does not exist

--- a/code/Test_definitions/device-identifier-retrieveIdentifier.feature
+++ b/code/Test_definitions/device-identifier-retrieveIdentifier.feature
@@ -51,7 +51,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.imei" exists and is equal to IMEI1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imeisv", if present, is equal to IMEISV1
     And the response property "$.tac", if present, is equal to TAC1
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
@@ -69,7 +69,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.imei" exists and is equal to IMEI1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imeisv", if present, is equal to IMEISV1
     And the response property "$.tac", if present, is equal to TAC1
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
@@ -88,7 +88,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.imei" exists and is equal to IMEI1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imeisv", if present, is equal to IMEISV1
     And the response property "$.tac", if present, is equal to TAC1
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
@@ -106,7 +106,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.imei" exists and is equal to IMEI1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imeisv", if present, is equal to IMEISV1
     And the response property "$.tac", if present, is equal to TAC1
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
@@ -124,7 +124,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.imei" exists and is equal to IMEI1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imeisv", if present, is equal to IMEISV1
     And the response property "$.tac", if present, is equal to TAC1
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
@@ -142,7 +142,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.imei" exists and is equal to IMEI2
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imeisv", if present, is equal to IMEISV2
     And the response property "$.tac", if present, is equal to TAC2
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER2
@@ -160,7 +160,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.imei" exists and is equal to IMEI2
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.imeisv", if present, is equal to IMEISV2
     And the response property "$.tac", if present, is equal to TAC2
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER2

--- a/code/Test_definitions/device-identifier-retrievePpid.feature
+++ b/code/Test_definitions/device-identifier-retrievePpid.feature
@@ -53,7 +53,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.ppid" exists and is equal to PPID1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
 
   # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrievePpid_200.02_success_scenario_2-legged_token_identifying_device_by_phone_number
@@ -67,7 +67,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.ppid" exists and is equal to PPID1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
 
   # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrievePpid_200.03_success_scenario_2-legged_token_identifying_device_by_IPv4_address
@@ -82,7 +82,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.ppid" exists and is equal to PPID1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
 
   # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_retrievePpid_200.04_success_scenario_3-legged_token_after_SIM_card_swap
@@ -96,7 +96,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.ppid" exists and is equal to PPID1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
 
   # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrievePpid_200.05_success_scenario_2-legged_token_after_SIM_card_swap
@@ -110,7 +110,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.ppid" exists and is equal to PPID1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
 
   # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_retrievePpid_200.06_success_scenario_3-legged_token_after_device_swap
@@ -124,7 +124,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.ppid" exists and is equal to PPID2
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
 
   # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrievePpid_200.07_success_scenario_2-legged_token_after_device_swap
@@ -138,7 +138,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.ppid" exists and is equal to PPID2
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
 
   # Generic 400 errors
 

--- a/code/Test_definitions/device-identifier-retrieveType.feature
+++ b/code/Test_definitions/device-identifier-retrieveType.feature
@@ -51,7 +51,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.tac" exists and is equal to TAC1
-    And the response property "$.lastChecked" exists and is either a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
@@ -67,7 +67,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.tac" exists and is equal to TAC1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
@@ -84,7 +84,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.tac" exists and is equal to TAC1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
@@ -100,7 +100,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.tac" exists and is equal to TAC1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
@@ -116,7 +116,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.tac" exists and is equal to TAC1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
@@ -132,7 +132,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.tac" exists and is equal to TAC2
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER2
     And the response property "$.model", if present, is equal to MODEL2
 
@@ -148,7 +148,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.tac" exists and is equal to TAC2
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past, or is null
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER2
     And the response property "$.model", if present, is equal to MODEL2
 


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
Allows `lastCheked` field to be nullable in case the API provider has no information as to when the information was last checked

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #183 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - [Changed] Make lastChecked property nullable and add examples
```

#### Additional documentation 
None