### PR TITLE
[Added] Update test cases for device identifier matching

### DIFF
--- a/code/Test_definitions/device-identifier-matchIdentifier.feature
+++ b/code/Test_definitions/device-identifier-matchIdentifier.feature
@@ -342,7 +342,8 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
       | IMEI                   | 12345678901234      |
       | IMEISV                 | 123456789012345     |
       | TAC                    | 1234567             |
-      | IMEI                   | 1234567890ABCD      |
+      | IMEI                   | 1234567890ABCDE     |
+      | IMEISV                 | 1234567890ABCDEF    |
       | TAC                    | 12!45678            |
 
   # Generic 401 errors


### PR DESCRIPTION
#### What type of PR is this?
* tests

#### What this PR does / why we need it:
Add additional test cases for match-identifier endpoint for when the provided identifier is the correct length but contains non-numeric identifiers.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #187 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Update test cases for device identifier matching
```

#### Additional documentation 
None