### PR TITLE
[Changed] Update and clarify tests for applicability to 2-legged and/or 3-legged access tokens

### DIFF
--- a/code/Test_definitions/device-identifier-matchIdentifier.feature
+++ b/code/Test_definitions/device-identifier-matchIdentifier.feature
@@ -415,7 +415,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
   # This scenario is valid only for 2-legged access tokens
   @DeviceIdentifier_matchIdentifier_404.1_device_not_found
   Scenario: An identifier cannot be matched to a valid device
-    Given that the device cannot be identified from the access token
+    Given the header "Authorization" is set to a valid access token that does not identify a device
     And the request body property "$.device" is compliant with the request body schema but does not identify a valid device
     And the request body property "$.providedIdentifierType" is set to "IMEI"
     And the request body property "$.providedIdentifier" is set to IMEI1

--- a/code/Test_definitions/device-identifier-matchIdentifier.feature
+++ b/code/Test_definitions/device-identifier-matchIdentifier.feature
@@ -454,26 +454,12 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.code" is "MISSING_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
-  @DeviceIdentifier_matchIdentifier_422.4_device_token_mismatch
-  Scenario: Inconsistent access token context for the device
-    Given the request body property "$.device" is set to a valid testing device
-    And the request body property "$.providedIdentifierType" is set to "IMEI"
-    And the request body property "$.providedIdentifier" is set to IMEI1
-    And the header "Authorization" is set to a valid access token obtained for a different device
-    When the request "matchIdentifier" is sent
-    Then the response status code is 422
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response header "Content-Type" is "application/json"
-    And the response property "$.status" is 422
-    And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
-    And the response property "$.message" contains a user friendly text
-
-  @DeviceIdentifier_matchIdentifier_422.5_unnecessary_device_identifier_in_request
-  Scenario: Explicit device identifier provided when device is identified by the access token
-    Given the request body property "$.device" is set to a valid testing device
-    And the request body property "$.providedIdentifierType" is set to "IMEI"
-    And the request body property "$.providedIdentifier" is set to IMEI1
-    And the header "Authorization" is set to a valid access token for that same device
+  @DeviceIdentifier_matchIdentifier_422.4_unnecessary_device_identifier_in_request
+  Scenario: Explicit device identifier provided when device is already identified by the access token
+    Given the header "Authorization" is set to a valid access token that identifies a device
+    And the request body property "$.providedIdentifierType" exists and is set to a valid value
+    And the request body property "$.providedIdentifier" exists and is set to a valid value
+    And the request body property "$.device" exists and is set to a valid value
     When the request "matchIdentifier" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/device-identifier-matchIdentifier.feature
+++ b/code/Test_definitions/device-identifier-matchIdentifier.feature
@@ -32,20 +32,21 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the resource "/device-identifier/vwip/match-identifier"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
-    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+    And the header "x-correlator" complies with the schema at "/components/schemas/XCorrelator"
     And the request body is compliant with the MatchRequestBody schema defined by "/components/schemas/MatchRequestBody"
     And one of the scopes associated with the access token is device-identifier:match-identifier
 
   # Success scenarios
 
+  # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_matchIdentifier_200.01_success_scenario_3-legged_token
   Scenario Outline: Match current device identifier for DEVICE1 with SIMCARD1 using 3-legged access token
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And SIMCARD1 is identified by the access token
+    And the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
     And request property "$.device" does not exist
     And request property "$.providedIdentifierType" is set to "<providedIdentifierType>"
     And request property "$.providedIdentifier" is set to <providedIdentifier>
-    When the HTTPS "POST" request is sent
+    When the request "matchIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200MatchIdentifier schema at "/components/schemas/200MatchIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -63,14 +64,15 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
       | IMEISV                 | IMEISV1            |
       | TAC                    | TAC1               |
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_matchIdentifier_200.02_success_scenario_2-legged_token_identifying_device_by_phone_number
   Scenario: Match current device identifier for DEVICE1 with SIMCARD1 identifying device by phone number
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER1
     And request property "$.providedIdentifierType" is set to "IMEI"
     And request property "$.providedIdentifier" is set to IMEI1
-    When the HTTPS "POST" request is sent
+    When the request "matchIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200MatchIdentifier schema at "/components/schemas/200MatchIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -82,14 +84,15 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.tac" does not exist
     And the response property "$.ppid" does not exist
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_matchIdentifier_200.02b_success_scenario_2-legged_token_identifying_device_by_phone_number_non_match
   Scenario: Non-match current device identifier for DEVICE1 with SIMCARD1 identifying device by phone number
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER1
     And request property "$.providedIdentifierType" is set to "IMEI"
     And request property "$.providedIdentifier" is set to IMEI2
-    When the HTTPS "POST" request is sent
+    When the request "matchIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200MatchIdentifier schema at "/components/schemas/200MatchIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -101,15 +104,16 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.tac" does not exist
     And the response property "$.ppid" does not exist
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_matchIdentifier_200.03_success_scenario_2-legged_token_identifying_device_by_IPv4_address
   Scenario: Match current device identifier for DEVICE1 with SIMCARD1 identifying device by IPv4 address
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.ipv4Address.publicAddress" is set to PUBLICIPV4ADDRESS1
     And request property "$.device.ipv4Address.publicPort" is set to PUBLICPORT1
     And request property "$.providedIdentifierType" is set to "TAC"
     And request property "$.providedIdentifier" is set to TAC1
-    When the HTTPS "POST" request is sent
+    When the request "matchIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200MatchIdentifier schema at "/components/schemas/200MatchIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -121,15 +125,16 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.tac" does not exist
     And the response property "$.ppid" does not exist
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_matchIdentifier_200.03b_success_scenario_2-legged_token_identifying_device_by_IPv4_address_non_match
   Scenario: Non-match current device identifier for DEVICE1 with SIMCARD1 identifying device by IPv4 address
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.ipv4Address.publicAddress" is set to PUBLICIPV4ADDRESS1
     And request property "$.device.ipv4Address.publicPort" is set to PUBLICPORT1
     And request property "$.providedIdentifierType" is set to "TAC"
     And request property "$.providedIdentifier" is set to TAC2
-    When the HTTPS "POST" request is sent
+    When the request "matchIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200MatchIdentifier schema at "/components/schemas/200MatchIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -141,16 +146,17 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.tac" does not exist
     And the response property "$.ppid" does not exist
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_matchIdentifier_200.04_success_scenario_2-legged_token_identifying_device_by_multiple_identifiers
   Scenario: Match current device identifier for DEVICE1 with SIMCARD1 identifying device by multiple identifiers
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER1
     And request property "$.device.ipv4Address.publicAddress" is set to PUBLICIPV4ADDRESS1
     And request property "$.device.ipv4Address.publicPort" is set to PUBLICPORT1
     And request property "$.providedIdentifierType" is set to "IMEISV"
     And request property "$.providedIdentifier" is set to IMEISV1
-    When the HTTPS "POST" request is sent
+    When the request "matchIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200MatchIdentifier schema at "/components/schemas/200MatchIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -162,16 +168,17 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.tac" does not exist
     And the response property "$.ppid" does not exist
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_matchIdentifier_200.04b_success_scenario_2-legged_token_identifying_device_by_multiple_identifiers_non_match
   Scenario: Non-match current device identifier for DEVICE1 with SIMCARD1 identifying device by multiple identifiers
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER1
     And request property "$.device.ipv4Address.publicAddress" is set to PUBLICIPV4ADDRESS1
     And request property "$.device.ipv4Address.publicPort" is set to PUBLICPORT1
     And request property "$.providedIdentifierType" is set to "IMEISV"
     And request property "$.providedIdentifier" is set to IMEISV2
-    When the HTTPS "POST" request is sent
+    When the request "matchIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200MatchIdentifier schema at "/components/schemas/200MatchIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -183,14 +190,15 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.tac" does not exist
     And the response property "$.ppid" does not exist
 
+  # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_matchIdentifier_200.05_success_scenario_3-legged_token_after_device_swap_mismatch
   Scenario Outline: Non-match for old device identifier after device swap using 3-legged access token
     Given SIMCARD1 is installed within DEVICE2, which is connected to the network
-    And SIMCARD1 is identified by the access token
+    And the header "Authorization" is set to a valid access token that identifies DEVICE2 containing SIMCARD1
     And request property "$.device" does not exist
     And request property "$.providedIdentifierType" is set to "<providedIdentifierType>"
     And request property "$.providedIdentifier" is set to <providedIdentifier>
-    When the HTTPS "POST" request is sent
+    When the request "matchIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200MatchIdentifier schema at "/components/schemas/200MatchIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -208,14 +216,15 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
       | IMEISV                 | IMEISV1            |
       | TAC                    | TAC1               |
 
+  # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_matchIdentifier_200.05b_success_scenario_3-legged_token_after_device_swap_match
   Scenario Outline: Match for new device identifier after device swap using 3-legged access token
     Given SIMCARD1 is installed within DEVICE2, which is connected to the network
-    And SIMCARD1 is identified by the access token
+    And the header "Authorization" is set to a valid access token that identifies DEVICE2 containing SIMCARD1
     And request property "$.device" does not exist
     And request property "$.providedIdentifierType" is set to "<providedIdentifierType>"
     And request property "$.providedIdentifier" is set to <providedIdentifier>
-    When the HTTPS "POST" request is sent
+    When the request "matchIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200MatchIdentifier schema at "/components/schemas/200MatchIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -233,14 +242,15 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
       | IMEISV                 | IMEISV2            |
       | TAC                    | TAC2               |
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_matchIdentifier_200.06_success_scenario_2-legged_token_after_SIM_card_swap
   Scenario: Match current device identifier for DEVICE1 with SIMCARD2 using 2-legged access token
     Given SIMCARD2 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER2
     And request property "$.providedIdentifierType" is set to "IMEI"
     And request property "$.providedIdentifier" is set to IMEI1
-    When the HTTPS "POST" request is sent
+    When the request "matchIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200MatchIdentifier schema at "/components/schemas/200MatchIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -254,6 +264,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
 
   # Generic 400 errors
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_matchIdentifier_400.1_schema_not_compliant
   Scenario: Invalid Argument. Generic Syntax Exception
     Given the request body is set to any value which is not compliant with the schema at "/components/schemas/MatchRequestBody"
@@ -265,6 +276,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_matchIdentifier_400.2_no_request_body
   Scenario: Missing request body
     Given the request body is not included
@@ -276,9 +288,10 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_matchIdentifier_400.2b_device_empty
   Scenario: The device value is an empty object
-    Given the request body property "$.device" is set to: {}
+    Given the request body property "$.device" exists and is set to: {}
     And the request body property "$.providedIdentifierType" is set to "IMEI"
     And the request body property "$.providedIdentifier" is set to IMEI1
     When the request "matchIdentifier" is sent
@@ -289,13 +302,14 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_matchIdentifier_400.3_device_identifiers_not_schema_compliant
   # Note that device schema validation errors (if any) should be thrown even if a 3-legged access token is being used
   Scenario Outline: Some device identifier value does not comply with the schema
-    Given the request body property "$.providedIdentifierType" is set to "IMEI"
+    Given a valid 2-legged or 3-legged access token is being used
+    And the request body property "$.providedIdentifierType" is set to "IMEI"
     And the request body property "$.providedIdentifier" is set to IMEI1
     And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
-    And a 2-legged or 3-legged access token is being used
     When the request "matchIdentifier" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -311,9 +325,10 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
       | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address |
       | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_matchIdentifier_400.4_invalid_identifier_type
   Scenario: Unsupported providedIdentifierType enum value
-    Given the request body property "$.device.phoneNumber" is set to PHONENUMBER1
+    Given a valid 2-legged or 3-legged access token is being used
     And the request body property "$.providedIdentifierType" is set to "INVALID_TYPE"
     And the request body property "$.providedIdentifier" is set to IMEI1
     When the request "matchIdentifier" is sent
@@ -324,9 +339,10 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_matchIdentifier_400.5_invalid_identifier_format
   Scenario Outline: Provided identifier does not comply with the format required by the identifier type
-    Given the request body property "$.device.phoneNumber" is set to PHONENUMBER1
+    Given a valid 2-legged or 3-legged access token is being used
     And the request body property "$.providedIdentifierType" is set to "<providedIdentifierType>"
     And the request body property "$.providedIdentifier" is set to "<providedIdentifier>"
     When the request "matchIdentifier" is sent
@@ -382,9 +398,10 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
 
   # Generic 403 errors
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_matchIdentifier_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope device-identifier:match-identifier
+    Given the header "Authorization" is set to a valid access token that does not include scope device-identifier:match-identifier
     When the request "matchIdentifier" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -395,6 +412,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
 
   # Generic 404 errors
 
+  # This scenario is valid only for 2-legged access tokens
   @DeviceIdentifier_matchIdentifier_404.1_device_not_found
   Scenario: An identifier cannot be matched to a valid device
     Given that the device cannot be identified from the access token
@@ -411,9 +429,11 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
 
   # Generic 422 errors
 
+  # This scenario is valid only for 2-legged access tokens
   @DeviceIdentifier_matchIdentifier_422.1_device_identifiers_unsupported
   Scenario: None of the provided device identifiers is supported by the implementation
-    Given that some type of device identifiers are not supported by the implementation
+    Given that some types of device identifiers are not supported by the implementation
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And the request body property "$.device" only includes device identifiers not supported by the implementation
     And the request body property "$.providedIdentifierType" is set to "IMEI"
     And the request body property "$.providedIdentifier" is set to IMEI1
@@ -425,11 +445,13 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_matchIdentifier_422.2_service_not_applicable
   Scenario: Service not applicable for the identified mobile device subscription
-    Given that service is not applicable for the identified mobile device subscription due to line type, policy, regulation, or no deterministic device information being available
-    And SIMCARD1 is identified by the access token
-    And request property "$.device" does not exist
+    #  The service may not be application due to, for example, line type, policy, regulation, or no deterministic device information being available
+    Given that the matchIdentifier service is not applicable for the identified mobile device subscription
+    And a valid 2-legged or 3-legged access token is being used
+    And a valid device is identified by the access token or the request body property "$.device"
     And the request body property "$.providedIdentifierType" is set to "IMEI"
     And the request body property "$.providedIdentifier" is set to IMEI1
     When the request "matchIdentifier" is sent
@@ -440,6 +462,7 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid only for 2-legged access tokens
   @DeviceIdentifier_matchIdentifier_422.3_unidentifiable_device
   Scenario: Device not included and cannot be deduced from the access token
     Given the header "Authorization" is set to a valid access token which does not identify a device
@@ -454,12 +477,28 @@ Feature: Camara Mobile Device Identifier API, vwip - Operation: matchIdentifier
     And the response property "$.code" is "MISSING_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
-  @DeviceIdentifier_matchIdentifier_422.4_unnecessary_device_identifier_in_request
-  Scenario: Explicit device identifier provided when device is already identified by the access token
-    Given the header "Authorization" is set to a valid access token that identifies a device
-    And the request body property "$.providedIdentifierType" exists and is set to a valid value
-    And the request body property "$.providedIdentifier" exists and is set to a valid value
-    And the request body property "$.device" exists and is set to a valid value
+  # This scenario is valid only for 3-legged access tokens
+  @DeviceIdentifier_matchIdentifier_422.4_device_token_mismatch
+  Scenario: Explicit device identifier provided when a 3-legged access token identifies a different device
+    Given the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
+    And the request body property "$.device" exists and identifies DEVICE2 containing SIMCARD2
+    And the request body property "$.providedIdentifierType" is set to "IMEI"
+    And the request body property "$.providedIdentifier" is set to IMEI1
+    When the request "matchIdentifier" is sent
+    Then the response status code is 422
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 422
+    And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
+    And the response property "$.message" contains a user friendly text
+
+  # This scenario is valid only for 3-legged access tokens
+  @DeviceIdentifier_matchIdentifier_422.5_unnecessary_device_identifier_in_request
+  Scenario: Explicit device identifier provided when a 3-legged access token identifies the same device
+    Given the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
+    And the request body property "$.device" exists and also identifies DEVICE1 containing SIMCARD1
+    And the request body property "$.providedIdentifierType" is set to "IMEI"
+    And the request body property "$.providedIdentifier" is set to IMEI1
     When the request "matchIdentifier" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/device-identifier-retrieveIdentifier.feature
+++ b/code/Test_definitions/device-identifier-retrieveIdentifier.feature
@@ -33,18 +33,19 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the resource "/device-identifier/vwip/retrieve-identifier"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
-    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+    And the header "x-correlator" complies with the schema at "/components/schemas/XCorrelator"
     And the request body is compliant with the RequestBody schema defined by "/components/schemas/RequestBody"
     And one of the scopes associated with the access token is device-identifier:retrieve-identifier
 
   # Success scenarios
 
+  # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_200.01_success_scenario_3-legged_token
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 using 3-legged access token
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And SIMCARD1 is identified by the access token
+    And the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
     And request property "$.device" does not exist
-    When the HTTPS "POST" request is sent
+    When the request "retrieveIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveIdentifier schema at "/components/schemas/200RetrieveIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -56,12 +57,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_200.02_success_scenario_2-legged_token_identifying_device_by_phone_number
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 identifying device by phone number
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER1
-    When the HTTPS "POST" request is sent
+    When the request "retrieveIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveIdentifier schema at "/components/schemas/200RetrieveIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -73,13 +75,14 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_200.03_success_scenario_2-legged_token_identifying_device_by_IPv4_address
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 identifying device by IPv4 address
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.ipv4Address.publicAddress" is set to PUBLICIPV4ADDRESS
     And request property "$.device.ipv4Address.publicPort" is set to PUBLICPORT
-    When the HTTPS "POST" request is sent
+    When the request "retrieveIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveIdentifier schema at "/components/schemas/200RetrieveIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -91,12 +94,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
+  # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_200.04_success_scenario_3-legged_token_after_SIM_card_swap
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD2 using 3-legged access token
     Given SIMCARD2 is installed within DEVICE1, which is connected to the network
-    And SIMCARD2 is identified by the access token
+    And the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD2
     And request property "$.device" does not exist
-    When the HTTPS "POST" request is sent
+    When the request "retrieveIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveIdentifier schema at "/components/schemas/200RetrieveIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -108,12 +112,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_200.05_success_scenario_2-legged_token_after_SIM_card_swap
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD2 using 2-legged access token
     Given SIMCARD2 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER2
-    When the HTTPS "POST" request is sent
+    When the request "retrieveIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveIdentifier schema at "/components/schemas/200RetrieveIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -125,12 +130,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
+  # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_200.06_success_scenario_3-legged_token_after_device_swap
   Scenario: Retrieve device identifier for DEVICE2 with SIM card SIMCARD1 using 3-legged access token
     Given SIMCARD1 is installed within DEVICE2, which is connected to the network
-    And SIMCARD1 is identified by the access token
+    And the header "Authorization" is set to a valid access token that identifies DEVICE2 containing SIMCARD1
     And request property "$.device" does not exist
-    When the HTTPS "POST" request is sent
+    When the request "retrieveIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveIdentifier schema at "/components/schemas/200RetrieveIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -142,12 +148,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER2
     And the response property "$.model", if present, is equal to MODEL2
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_200.07_success_scenario_2-legged_token_after_device_swap
   Scenario: Retrieve device identifier for DEVICE2 with SIM card SIMCARD1 using 2-legged access token
     Given SIMCARD1 is installed within DEVICE2, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER1
-    When the HTTPS "POST" request is sent
+    When the request "retrieveIdentifier" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveIdentifier schema at "/components/schemas/200RetrieveIdentifier"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -161,6 +168,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
 
   # Generic 400 errors
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_400.1_schema_not_compliant
   Scenario: Invalid Argument. Generic Syntax Exception
     Given the request body is set to any value which is not compliant with the schema at "/components/schemas/RequestBody"
@@ -172,6 +180,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_400.2_no_request_body
   Scenario: Missing request body
     Given the request body is not included
@@ -183,6 +192,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_400.3_device_empty
   Scenario: The device value is an empty object
     Given the request body property "$.device" is set to: {}
@@ -194,12 +204,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_400.4_device_identifiers_not_schema_compliant
   # Test every type of identifier even if not supported by the implementation
   # Note that device schema validation errors (if any) should be thrown even if a 3-legged access token is being used
   Scenario Outline: Some device identifier value does not comply with the schema
-    Given the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
-    And a 2-legged or 3-legged access token is being used
+    Given a valid 2-legged or 3-legged access token is being used
+    And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
     When the request "retrieveIdentifier" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -215,10 +226,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
       | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
       | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
+  # This scenario is only valid for 2-legged access tokens
   # The maximum is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction, and both could be accepted
   @DeviceIdentifier_retrieveIdentifier_400.5_out_of_range_port
   Scenario: Out of range port
-    Given the request body property  "$.device.ipv4Address.publicPort" is set to a value not between 0 and 65535
+    And the header "Authorization" is set to a valid access token that does not identify a device
+    And the request body property "$.device.ipv4Address.publicPort" is set to a value not between 0 and 65535
     When the request "retrieveIdentifier" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -265,9 +278,10 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
 
   # Generic 403 errors
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope device-identifier:retrieve-identifier
+    Given the header "Authorization" is set to a valid access token that does not include scope device-identifier:retrieve-identifier
     When the request "retrieveIdentifier" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -278,10 +292,10 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
 
   # Generic 404 errors
 
-  # Typically with a 2-legged access token when the identified device is managed by a different API provider
+  # This scenario is valid only for 2-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_404.1_device_not_found
   Scenario: An identifier cannot be matched to a valid device
-    Given that the device cannot be identified from the access token
+    Given the header "Authorization" is set to a valid access token that does not identify a device
     And the request body property "$.device" is compliant with the request body schema but does not identify a valid device
     When the request "retrieveIdentifier" is sent
     Then the response status code is 404
@@ -293,9 +307,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
 
   # Generic 422 errors
 
+  # This scenario is valid only for 2-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_422.1_device_identifiers_unsupported
   Scenario: None of the provided device identifiers is supported by the implementation
     Given that some type of device identifiers are not supported by the implementation
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And the request body property "$.device" only includes device identifiers not supported by the implementation
     When the request "retrieveIdentifier" is sent
     Then the response status code is 422
@@ -305,10 +321,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_422.2_device_not_supported
   Scenario: Service not available for the device
-    Given that service is not supported for all devices commercialized by the operator
-    And the service is not applicable for the device identified by the token or provided in the request body
+    #  The service may not be application due to, for example, line type, policy, regulation, or no deterministic device information being available
+    Given that the retrieveIdentifier service is not applicable for the identified device
+    And a valid 2-legged or 3-legged access token is being used
+    And a valid device is identified by the access token or the request body property "$.device"
     When the request "retrieveIdentifier" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -317,7 +336,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user friendly text
 
-  # Typically with a 2-legged access token
+  # This scenario is valid only for 2-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_422.3_unidentifiable_device
   Scenario: Device not included and cannot be deduced from the access token
     Given the header "Authorization" is set to a valid access token which does not identify a device
@@ -330,12 +349,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.code" is "MISSING_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
-  # Typically with a 3-legged access token
+  # This scenario is valid only for 3-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_422.4_device_token_mismatch
   Scenario: Inconsistent access token context for the device
-    # To test this, a token has to be obtained for a different device
-    Given the request body property "$.device" is set to a valid testing device
-    And the header "Authorization" is set to a valid access token obtained for a different device
+  Scenario: Explicit device identifier provided when a 3-legged access token identifies a different device
+    Given the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
+    And the request body property "$.device" exists and identifies DEVICE2 containing SIMCARD2
     When the request "retrieveIdentifier" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -344,11 +363,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
     And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
-  # Typically with a 3-legged access token
+  # This scenario is valid only for 3-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_422.5_unnecessary_device_identifier_in_request
-  Scenario: Explicit device identifier provided when device is identified by the access token
-    Given the request body property "$.device" is set to a valid testing device
-    And the header "Authorization" is set to a valid access token for that same device
+  Scenario: Explicit device identifier provided when a 3-legged access token identifies the same device
+    Given the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
+    And the request body property "$.device" exists and also identifies DEVICE1 containing SIMCARD1
     When the request "retrieveIdentifier" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/device-identifier-retrieveIdentifier.feature
+++ b/code/Test_definitions/device-identifier-retrieveIdentifier.feature
@@ -230,7 +230,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
   # The maximum is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction, and both could be accepted
   @DeviceIdentifier_retrieveIdentifier_400.5_out_of_range_port
   Scenario: Out of range port
-    And the header "Authorization" is set to a valid access token that does not identify a device
+    Given the header "Authorization" is set to a valid access token that does not identify a device
     And the request body property "$.device.ipv4Address.publicPort" is set to a value not between 0 and 65535
     When the request "retrieveIdentifier" is sent
     Then the response status code is 400

--- a/code/Test_definitions/device-identifier-retrieveIdentifier.feature
+++ b/code/Test_definitions/device-identifier-retrieveIdentifier.feature
@@ -351,7 +351,6 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveIdentifie
 
   # This scenario is valid only for 3-legged access tokens
   @DeviceIdentifier_retrieveIdentifier_422.4_device_token_mismatch
-  Scenario: Inconsistent access token context for the device
   Scenario: Explicit device identifier provided when a 3-legged access token identifies a different device
     Given the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
     And the request body property "$.device" exists and identifies DEVICE2 containing SIMCARD2

--- a/code/Test_definitions/device-identifier-retrievePpid.feature
+++ b/code/Test_definitions/device-identifier-retrievePpid.feature
@@ -41,10 +41,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
 
   # Success scenarios
 
+  # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_retrievePpid_200.01_success_scenario_3-legged_token
   Scenario: Retrieve device PPID for DEVICE1 with SIM card SIMCARD1 using 3-legged access token
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And SIMCARD1 is identified by the access token
+    And the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
     And request property "$.device" does not exist
     When the request "retrievePpid" is sent
     Then the response status code is 200
@@ -54,10 +55,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response property "$.ppid" exists and is equal to PPID1
     And the response property "$.lastChecked" exists and is a valid date-time in the past
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrievePpid_200.02_success_scenario_2-legged_token_identifying_device_by_phone_number
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 identifying device by phone number
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER1
     When the request "retrievePpid" is sent
     Then the response status code is 200
@@ -67,10 +69,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response property "$.ppid" exists and is equal to PPID1
     And the response property "$.lastChecked" exists and is a valid date-time in the past
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrievePpid_200.03_success_scenario_2-legged_token_identifying_device_by_IPv4_address
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 identifying device by IPv4 address
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.ipv4Address.publicAddress" is set to PUBLICIPV4ADDRESS
     And request property "$.device.ipv4Address.publicPort" is set to PUBLICPORT
     When the request "retrievePpid" is sent
@@ -81,10 +84,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response property "$.ppid" exists and is equal to PPID1
     And the response property "$.lastChecked" exists and is a valid date-time in the past
 
+  # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_retrievePpid_200.04_success_scenario_3-legged_token_after_SIM_card_swap
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD2 using 3-legged access token
     Given SIMCARD2 is installed within DEVICE1, which is connected to the network
-    And SIMCARD2 is identified by the access token
+    And the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD2
     And request property "$.device" does not exist
     When the request "retrievePpid" is sent
     Then the response status code is 200
@@ -94,10 +98,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response property "$.ppid" exists and is equal to PPID1
     And the response property "$.lastChecked" exists and is a valid date-time in the past
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrievePpid_200.05_success_scenario_2-legged_token_after_SIM_card_swap
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD2 using 2-legged access token
     Given SIMCARD2 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER2
     When the request "retrievePpid" is sent
     Then the response status code is 200
@@ -107,10 +112,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response property "$.ppid" exists and is equal to PPID1
     And the response property "$.lastChecked" exists and is a valid date-time in the past
 
+  # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_retrievePpid_200.06_success_scenario_3-legged_token_after_device_swap
   Scenario: Retrieve device identifier for DEVICE2 with SIM card SIMCARD1 using 3-legged access token
     Given SIMCARD1 is installed within DEVICE2, which is connected to the network
-    And SIMCARD1 is identified by the access token
+    And the header "Authorization" is set to a valid access token that identifies DEVICE2 containing SIMCARD1
     And request property "$.device" does not exist
     When the request "retrievePpid" is sent
     Then the response status code is 200
@@ -120,10 +126,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response property "$.ppid" exists and is equal to PPID2
     And the response property "$.lastChecked" exists and is a valid date-time in the past
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrievePpid_200.07_success_scenario_2-legged_token_after_device_swap
   Scenario: Retrieve device identifier for DEVICE2 with SIM card SIMCARD1 using 2-legged access token
     Given SIMCARD1 is installed within DEVICE2, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER1
     When the request "retrievePpid" is sent
     Then the response status code is 200
@@ -135,6 +142,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
 
   # Generic 400 errors
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrievePpid_400.1_schema_not_compliant
   Scenario: Invalid Argument. Generic Syntax Exception
     Given the request body is set to any value which is not compliant with the schema at "/components/schemas/RequestBody"
@@ -146,6 +154,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrievePpid_400.2_no_request_body
   Scenario: Missing request body
     Given the request body is not included
@@ -157,6 +166,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrievePpid_400.3_device_empty
   Scenario: The device value is an empty object
     Given the request body property "$.device" is set to: {}
@@ -168,12 +178,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrievePpid_400.4_device_identifiers_not_schema_compliant
   # Test every type of identifier even if not supported by the implementation
   # Note that device schema validation errors (if any) should be thrown even if a 3-legged access token is being used
   Scenario Outline: Some device identifier value does not comply with the schema
-    Given the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
-    And a 2-legged or 3-legged access token is being used
+    Given a 2-legged or 3-legged access token is being used
+    And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
     When the request "retrievePpid" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -189,10 +200,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
       | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
       | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
+  # This scenario is only valid for 2-legged access tokens
   # The maximum is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction, and both could be accepted
   @DeviceIdentifier_retrievePpid_400.5_out_of_range_port
   Scenario: Out of range port
-    Given the request body property  "$.device.ipv4Address.publicPort" is set to a value not between 0 and 65535
+    Given the header "Authorization" is set to a valid access token that does not identify a device
+    And the request body property "$.device.ipv4Address.publicPort" is set to a value not between 0 and 65535
     When the request "retrievePpid" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -239,6 +252,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
 
   # Generic 403 errors
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrievePpid_403.1_missing_access_token_scope
   Scenario: Missing access token scope
     Given the header "Authorization" is set to a valid access token that does not include scope device-identifier:retrieve-ppid
@@ -252,7 +266,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
 
   # Generic 404 errors
 
-  # This scenario usually occurs for a 2-legged access token when the identified device is managed by a different API provider
+  # This scenario is valid only for 2-legged access tokens
   @DeviceIdentifier_retrievePpid_404.1_device_not_found
   Scenario: An identifier cannot be matched to a valid device
     Given the header "Authorization" is set to a valid access token that does not identify a device

--- a/code/Test_definitions/device-identifier-retrievePpid.feature
+++ b/code/Test_definitions/device-identifier-retrievePpid.feature
@@ -310,9 +310,8 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
   # This scenario is only applicable to 3-legged access tokens
   @DeviceIdentifier_retrievePpid_422.4_device_token_mismatch
   Scenario: Explicit device identifier provided when a 3-legged access token is being used
-    # To test this, an access token has to be obtained for a different device
-    Given the header "Authorization" is set to a valid access token that identifies a device
-    And the request body property "$.device" exists and identifies a different device
+    Given the header "Authorization" is set to a valid access token that identifies the DEVICE1 containing SIMCARD1
+    And the request body property "$.device" exists and identifies DEVICE2 containing SIMCARD2
     When the request "retrievePpid" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -324,8 +323,8 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
   # This scenario is only applicable to 3-legged access tokens
   @DeviceIdentifier_retrievePpid_422.5_unnecessary_device_identifier_in_request
   Scenario: Explicit device identifier provided when device is identified by the access token
-    Given the header "Authorization" is set to a valid access token that identifies a device
-    And the request body property "$.device" exists and identifies that same device
+    Given the header "Authorization" is set to a valid access token that identifies the DEVICE1 containing SIMCARD1
+    And the request body property "$.device" exists and identifies DEVICE1 containing SIMCARD1
     When the request "retrievePpid" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"

--- a/code/Test_definitions/device-identifier-retrievePpid.feature
+++ b/code/Test_definitions/device-identifier-retrievePpid.feature
@@ -309,7 +309,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
 
   # This scenario is only applicable to 3-legged access tokens
   @DeviceIdentifier_retrievePpid_422.4_device_token_mismatch
-  Scenario: Explicit device identifier provided when a 3-legged access token is being used
+  Scenario: Explicit device identifier provided when a 3-legged access token identifies a different device
     Given the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
     And the request body property "$.device" exists and identifies DEVICE2 containing SIMCARD2
     When the request "retrievePpid" is sent
@@ -322,7 +322,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
 
   # This scenario is only applicable to 3-legged access tokens
   @DeviceIdentifier_retrievePpid_422.5_unnecessary_device_identifier_in_request
-  Scenario: Explicit device identifier provided when device is identified by the access token
+  Scenario: Explicit device identifier provided when a 3-legged access token identifies the same device
     Given the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
     And the request body property "$.device" exists and identifies DEVICE1 containing SIMCARD1
     When the request "retrievePpid" is sent

--- a/code/Test_definitions/device-identifier-retrievePpid.feature
+++ b/code/Test_definitions/device-identifier-retrievePpid.feature
@@ -1,5 +1,5 @@
-# device-identifier-retrievePPID
-Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
+# device-identifier-retrievePpid
+Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
 
   # Input to be provided by the implementation to the tests
   # References to OAS spec schemas refer to schemas specified in /code/API_definitions/device-identifier.yaml
@@ -30,7 +30,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
   # * A SIM card "SIMCARD1" from "TELCO1" and phone number "PHONENUMBER1"
   # * A SIM card "SIMCARD2" from "TELCO2" and phone number "PHONENUMBER2"
 
-  Background: Common Device Identifier retrievePPID setup
+  Background: Common Device Identifier retrievePpid setup
     Given an environment at "apiRoot"
     And the resource "/device-identifier/vwip/retrieve-ppid"
     And the header "Content-Type" is set to "application/json"
@@ -41,12 +41,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
 
   # Success scenarios
 
-  @DeviceIdentifier_retrievePPID_200.01_success_scenario_3-legged_token
+  @DeviceIdentifier_retrievePpid_200.01_success_scenario_3-legged_token
   Scenario: Retrieve device PPID for DEVICE1 with SIM card SIMCARD1 using 3-legged access token
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
     And SIMCARD1 is identified by the access token
     And request property "$.device" does not exist
-    When the HTTPS "POST" request is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrievePPID schema at "/components/schemas/200RetrievePPID"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -54,12 +54,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.ppid" exists and is equal to PPID1
     And the response property "$.lastChecked" exists and is a valid date-time in the past
 
-  @DeviceIdentifier_retrievePPID_200.02_success_scenario_2-legged_token_identifying_device_by_phone_number
+  @DeviceIdentifier_retrievePpid_200.02_success_scenario_2-legged_token_identifying_device_by_phone_number
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 identifying device by phone number
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
     And no subject is identified by the access token
     And request property "$.device.phoneNumber" is set to PHONENUMBER1
-    When the HTTPS "POST" request is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrievePPID schema at "/components/schemas/200RetrievePPID"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -67,13 +67,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.ppid" exists and is equal to PPID1
     And the response property "$.lastChecked" exists and is a valid date-time in the past
 
-  @DeviceIdentifier_retrievePPID_200.03_success_scenario_2-legged_token_identifying_device_by_IPv4_address
+  @DeviceIdentifier_retrievePpid_200.03_success_scenario_2-legged_token_identifying_device_by_IPv4_address
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 identifying device by IPv4 address
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
     And no subject is identified by the access token
     And request property "$.device.ipv4Address.publicAddress" is set to PUBLICIPV4ADDRESS
     And request property "$.device.ipv4Address.publicPort" is set to PUBLICPORT
-    When the HTTPS "POST" request is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrievePPID schema at "/components/schemas/200RetrievePPID"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -81,12 +81,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.ppid" exists and is equal to PPID1
     And the response property "$.lastChecked" exists and is a valid date-time in the past
 
-  @DeviceIdentifier_retrievePPID_200.04_success_scenario_3-legged_token_after_SIM_card_swap
+  @DeviceIdentifier_retrievePpid_200.04_success_scenario_3-legged_token_after_SIM_card_swap
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD2 using 3-legged access token
     Given SIMCARD2 is installed within DEVICE1, which is connected to the network
     And SIMCARD2 is identified by the access token
     And request property "$.device" does not exist
-    When the HTTPS "POST" request is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrievePPID schema at "/components/schemas/200RetrievePPID"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -94,12 +94,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.ppid" exists and is equal to PPID1
     And the response property "$.lastChecked" exists and is a valid date-time in the past
 
-  @DeviceIdentifier_retrievePPID_200.05_success_scenario_2-legged_token_after_SIM_card_swap
+  @DeviceIdentifier_retrievePpid_200.05_success_scenario_2-legged_token_after_SIM_card_swap
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD2 using 2-legged access token
     Given SIMCARD2 is installed within DEVICE1, which is connected to the network
     And no subject is identified by the access token
     And request property "$.device.phoneNumber" is set to PHONENUMBER2
-    When the HTTPS "POST" request is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrievePPID schema at "/components/schemas/200RetrievePPID"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -107,12 +107,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.ppid" exists and is equal to PPID1
     And the response property "$.lastChecked" exists and is a valid date-time in the past
 
-  @DeviceIdentifier_retrievePPID_200.06_success_scenario_3-legged_token_after_device_swap
+  @DeviceIdentifier_retrievePpid_200.06_success_scenario_3-legged_token_after_device_swap
   Scenario: Retrieve device identifier for DEVICE2 with SIM card SIMCARD1 using 3-legged access token
     Given SIMCARD1 is installed within DEVICE2, which is connected to the network
     And SIMCARD1 is identified by the access token
     And request property "$.device" does not exist
-    When the HTTPS "POST" request is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrievePPID schema at "/components/schemas/200RetrievePPID"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -120,12 +120,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.ppid" exists and is equal to PPID2
     And the response property "$.lastChecked" exists and is a valid date-time in the past
 
-  @DeviceIdentifier_retrievePPID_200.07_success_scenario_2-legged_token_after_device_swap
+  @DeviceIdentifier_retrievePpid_200.07_success_scenario_2-legged_token_after_device_swap
   Scenario: Retrieve device identifier for DEVICE2 with SIM card SIMCARD1 using 2-legged access token
     Given SIMCARD1 is installed within DEVICE2, which is connected to the network
     And no subject is identified by the access token
     And request property "$.device.phoneNumber" is set to PHONENUMBER1
-    When the HTTPS "POST" request is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrievePPID schema at "/components/schemas/200RetrievePPID"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -135,10 +135,10 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
 
   # Generic 400 errors
 
-  @DeviceIdentifier_retrievePPID_400.1_schema_not_compliant
+  @DeviceIdentifier_retrievePpid_400.1_schema_not_compliant
   Scenario: Invalid Argument. Generic Syntax Exception
     Given the request body is set to any value which is not compliant with the schema at "/components/schemas/RequestBody"
-    When the request "retrievePPID" is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -146,10 +146,10 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @DeviceIdentifier_retrievePPID_400.2_no_request_body
+  @DeviceIdentifier_retrievePpid_400.2_no_request_body
   Scenario: Missing request body
     Given the request body is not included
-    When the request "retrievePPID" is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -157,10 +157,10 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @DeviceIdentifier_retrievePPID_400.3_device_empty
+  @DeviceIdentifier_retrievePpid_400.3_device_empty
   Scenario: The device value is an empty object
     Given the request body property "$.device" is set to: {}
-    When the request "retrievePPID" is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -168,13 +168,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @DeviceIdentifier_retrievePPID_400.4_device_identifiers_not_schema_compliant
+  @DeviceIdentifier_retrievePpid_400.4_device_identifiers_not_schema_compliant
   # Test every type of identifier even if not supported by the implementation
   # Note that device schema validation errors (if any) should be thrown even if a 3-legged access token is being used
   Scenario Outline: Some device identifier value does not comply with the schema
     Given the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
     And a 2-legged or 3-legged access token is being used
-    When the request "retrievePPID" is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -190,10 +190,10 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
       | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
   # The maximum is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction, and both could be accepted
-  @DeviceIdentifier_retrievePPID_400.5_out_of_range_port
+  @DeviceIdentifier_retrievePpid_400.5_out_of_range_port
   Scenario: Out of range port
     Given the request body property  "$.device.ipv4Address.publicPort" is set to a value not between 0 and 65535
-    When the request "retrievePPID" is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -203,10 +203,10 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
 
   # Generic 401 errors
 
-  @DeviceIdentifier_retrievePPID_401.1_no_authorization_header
+  @DeviceIdentifier_retrievePpid_401.1_no_authorization_header
   Scenario: No Authorization header
     Given the header "Authorization" is removed
-    When the request "retrievePPID" is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 401
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -215,10 +215,10 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.message" contains a user friendly text
 
   # In this case both codes could make sense depending on whether the access token can be refreshed or not
-  @DeviceIdentifier_retrievePPID_401.2_expired_access_token
+  @DeviceIdentifier_retrievePpid_401.2_expired_access_token
   Scenario: Expired access token
     Given the header "Authorization" is set to an expired access token
-    When the request "retrievePPID" is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 401
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -226,10 +226,10 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @DeviceIdentifier_retrievePPID_401.3_invalid_access_token
+  @DeviceIdentifier_retrievePpid_401.3_invalid_access_token
   Scenario: Invalid access token
     Given the header "Authorization" is set to an invalid access token
-    When the request "retrievePPID" is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 401
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -239,10 +239,10 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
 
   # Generic 403 errors
 
-  @DeviceIdentifier_retrievePPID_403.1_missing_access_token_scope
+  @DeviceIdentifier_retrievePpid_403.1_missing_access_token_scope
   Scenario: Missing access token scope
     Given the header "Authorization" is set to an access token that does not include scope device-identifier:retrieve-ppid
-    When the request "retrievePPID" is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -252,12 +252,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
 
   # Generic 404 errors
 
-  # Typically with a 2-legged access token when the identified device is managed by a different API provider
-  @DeviceIdentifier_retrievePPID_404.1_device_not_found
+  # This scenario usually occurs for a 2-legged access token when the identified device is managed by a different API provider
+  @DeviceIdentifier_retrievePpid_404.1_device_not_found
   Scenario: An identifier cannot be matched to a valid device
     Given that the device cannot be identified from the access token
     And the request body property "$.device" is compliant with the request body schema but does not identify a valid device
-    When the request "retrievePPID" is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 404
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -267,11 +267,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
 
   # Generic 422 errors
 
-  @DeviceIdentifier_retrievePPID_422.1_device_identifiers_unsupported
-  Scenario: None of the provided device identifiers is supported by the implementation
-    Given that some type of device identifiers are not supported by the implementation
-    And the request body property "$.device" only includes device identifiers not supported by the implementation
-    When the request "retrievePPID" is sent
+  # This scenario is only applicable to 2-legged access tokens
+  @DeviceIdentifier_retrievePpid_422.1_unsupported_device_identifier
+  Scenario: A 2-legged access token is used, but none of the provided device identifiers is supported by the implementation
+    Given that some types of device identifiers are not supported by the implementation
+    And the header "Authorization" is set to an access token that does not identify a device
+    And the request body property "$.device" exists but only includes device identifiers that are not supported by the implementation
+    When the request "retrievePpid" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -279,11 +281,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
-  @DeviceIdentifier_retrievePPID_422.2_device_not_supported
+  # This scenario is applicable for both 3-legged and 2-legged access tokens
+  @DeviceIdentifier_retrievePpid_422.2_device_not_supported
   Scenario: Service not available for the device
     Given that service is not supported for all devices commercialized by the operator
     And the service is not applicable for the device identified by the token or provided in the request body
-    When the request "retrievePPID" is sent
+    When the request "retrievePpid" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -291,12 +294,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user friendly text
 
-  # Typically with a 2-legged access token
-  @DeviceIdentifier_retrievePPID_422.3_unidentifiable_device
-  Scenario: Device not included and cannot be deduced from the access token
+  # This scenario is only applicable to 2-legged access tokens
+  @DeviceIdentifier_retrievePpid_422.3_unidentifiable_device
+  Scenario: Device identifier not included and cannot be deduced from the access token
     Given the header "Authorization" is set to a valid access token which does not identify a device
-    And the request body property "$.device" is not included
-    When the request "retrievePPID" is sent
+    And the request body property "$.device" does not exist
+    When the request "retrievePpid" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -304,13 +307,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.code" is "MISSING_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
-  # Typically with a 3-legged access token
-  @DeviceIdentifier_retrievePPID_422.4_device_token_mismatch
-  Scenario: Inconsistent access token context for the device
-    # To test this, a token has to be obtained for a different device
-    Given the request body property "$.device" is set to a valid testing device
-    And the header "Authorization" is set to a valid access token obtained for a different device
-    When the request "retrievePPID" is sent
+  # This scenario is only applicable to 3-legged access tokens
+  @DeviceIdentifier_retrievePpid_422.4_device_token_mismatch
+  Scenario: Explicit device identifier provided when a 3-legged access token is being used
+    # To test this, an access token has to be obtained for a different device
+    Given the header "Authorization" is set to a valid access token that identifies a device
+    And the request body property "$.device" exists and identifies a different device
+    When the request "retrievePpid" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
@@ -318,12 +321,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePPID
     And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
-  # Typically with a 3-legged access token
-  @DeviceIdentifier_retrievePPID_422.5_unnecessary_device_identifier_in_request
+  # This scenario is only applicable to 3-legged access tokens
+  @DeviceIdentifier_retrievePpid_422.5_unnecessary_device_identifier_in_request
   Scenario: Explicit device identifier provided when device is identified by the access token
-    Given the request body property "$.device" is set to a valid testing device
-    And the header "Authorization" is set to a valid access token for that same device
-    When the request "retrievePPID" is sent
+    Given the header "Authorization" is set to a valid access token that identifies a device
+    And the request body property "$.device" exists and identifies that same device
+    When the request "retrievePpid" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/device-identifier-retrievePpid.feature
+++ b/code/Test_definitions/device-identifier-retrievePpid.feature
@@ -35,7 +35,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
     And the resource "/device-identifier/vwip/retrieve-ppid"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
-    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+    And the header "x-correlator" complies with the schema at "/components/schemas/XCorrelator"
     And the request body is compliant with the RequestBody schema defined by "/components/schemas/RequestBody"
     And one of the scopes associated with the access token is device-identifier:retrieve-ppid
 

--- a/code/Test_definitions/device-identifier-retrievePpid.feature
+++ b/code/Test_definitions/device-identifier-retrievePpid.feature
@@ -241,7 +241,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
 
   @DeviceIdentifier_retrievePpid_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope device-identifier:retrieve-ppid
+    Given the header "Authorization" is set to a valid access token that does not include scope device-identifier:retrieve-ppid
     When the request "retrievePpid" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -255,7 +255,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
   # This scenario usually occurs for a 2-legged access token when the identified device is managed by a different API provider
   @DeviceIdentifier_retrievePpid_404.1_device_not_found
   Scenario: An identifier cannot be matched to a valid device
-    Given that the device cannot be identified from the access token
+    Given the header "Authorization" is set to a valid access token that does not identify a device
     And the request body property "$.device" is compliant with the request body schema but does not identify a valid device
     When the request "retrievePpid" is sent
     Then the response status code is 404
@@ -271,7 +271,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
   @DeviceIdentifier_retrievePpid_422.1_unsupported_device_identifier
   Scenario: A 2-legged access token is used, but none of the provided device identifiers is supported by the implementation
     Given that some types of device identifiers are not supported by the implementation
-    And the header "Authorization" is set to an access token that does not identify a device
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And the request body property "$.device" exists but only includes device identifiers that are not supported by the implementation
     When the request "retrievePpid" is sent
     Then the response status code is 422
@@ -310,7 +310,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
   # This scenario is only applicable to 3-legged access tokens
   @DeviceIdentifier_retrievePpid_422.4_device_token_mismatch
   Scenario: Explicit device identifier provided when a 3-legged access token is being used
-    Given the header "Authorization" is set to a valid access token that identifies the DEVICE1 containing SIMCARD1
+    Given the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
     And the request body property "$.device" exists and identifies DEVICE2 containing SIMCARD2
     When the request "retrievePpid" is sent
     Then the response status code is 422
@@ -323,7 +323,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrievePpid
   # This scenario is only applicable to 3-legged access tokens
   @DeviceIdentifier_retrievePpid_422.5_unnecessary_device_identifier_in_request
   Scenario: Explicit device identifier provided when device is identified by the access token
-    Given the header "Authorization" is set to a valid access token that identifies the DEVICE1 containing SIMCARD1
+    Given the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
     And the request body property "$.device" exists and identifies DEVICE1 containing SIMCARD1
     When the request "retrievePpid" is sent
     Then the response status code is 422

--- a/code/Test_definitions/device-identifier-retrieveType.feature
+++ b/code/Test_definitions/device-identifier-retrieveType.feature
@@ -33,33 +33,35 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the resource "/device-identifier/vwip/retrieve-type"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
-    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+    And the header "x-correlator" complies with the schema at "/components/schemas/XCorrelator"
     And the request body is compliant with the RequestBody schema defined by "/components/schemas/RequestBody"
     And one of the scopes associated with the access token is device-identifier:retrieve-type
 
   # Success scenarios
 
+  # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_retrieveType_200.01_success_scenario_3-legged_token
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 using 3-legged access token
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And SIMCARD1 is identified by the access token
+    And the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
     And request property "$.device" does not exist
-    When the HTTPS "POST" request is sent
+    When the request "retrieveType" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveType schema at "/components/schemas/200RetrieveType"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.tac" exists and is equal to TAC1
-    And the response property "$.lastChecked" exists and is a valid date-time in the past
+    And the response property "$.lastChecked" exists and is either a valid date-time in the past
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrieveType_200.02_success_scenario_2-legged_token_identifying_device_by_phone_number
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 identifying device by phone number
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER1
-    When the HTTPS "POST" request is sent
+    When the request "retrieveType" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveType schema at "/components/schemas/200RetrieveType"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -69,13 +71,14 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrieveType_200.03_success_scenario_2-legged_token_identifying_device_by_IPv4_address
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD1 identifying device by IPv4 address
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.ipv4Address.publicAddress" is set to PUBLICIPV4ADDRESS
     And request property "$.device.ipv4Address.publicPort" is set to PUBLICPORT
-    When the HTTPS "POST" request is sent
+    When the request "retrieveType" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveType schema at "/components/schemas/200RetrieveType"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -85,12 +88,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
+  # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_retrieveType_200.04_success_scenario_3-legged_token_after_SIM_card_swap
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD2 using 3-legged access token
     Given SIMCARD2 is installed within DEVICE1, which is connected to the network
-    And SIMCARD2 is identified by the access token
+    And the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD2
     And request property "$.device" does not exist
-    When the HTTPS "POST" request is sent
+    When the request "retrieveType" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveType schema at "/components/schemas/200RetrieveType"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -100,12 +104,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrieveType_200.05_success_scenario_2-legged_token_after_SIM_card_swap
   Scenario: Retrieve device identifier for DEVICE1 with SIM card SIMCARD2 using 2-legged access token
     Given SIMCARD1 is installed within DEVICE1, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER2
-    When the HTTPS "POST" request is sent
+    When the request "retrieveType" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveType schema at "/components/schemas/200RetrieveType"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -115,12 +120,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER1
     And the response property "$.model", if present, is equal to MODEL1
 
+  # This scenario is only valid for 3-legged access tokens
   @DeviceIdentifier_retrieveType_200.06_success_scenario_3-legged_token_after_device_swap
   Scenario: Retrieve device identifier for DEVICE2 with SIM card SIMCARD1 using 3-legged access token
     Given SIMCARD1 is installed within DEVICE2, which is connected to the network
-    And SIMCARD1 is identified by the access token
+    And the header "Authorization" is set to a valid access token that identifies DEVICE2 containing SIMCARD1
     And request property "$.device" does not exist
-    When the HTTPS "POST" request is sent
+    When the request "retrieveType" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveType schema at "/components/schemas/200RetrieveType"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -130,12 +136,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response property "$.manufacturer", if present, is equal to MANUFACTURER2
     And the response property "$.model", if present, is equal to MODEL2
 
+  # This scenario is only valid for 2-legged access tokens
   @DeviceIdentifier_retrieveType_200.07_success_scenario_2-legged_token_after_device_swap
   Scenario: Retrieve device identifier for DEVICE2 with SIM card SIMCARD1 using 2-legged access token
     Given SIMCARD1 is installed within DEVICE2, which is connected to the network
-    And no subject is identified by the access token
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And request property "$.device.phoneNumber" is set to PHONENUMBER1
-    When the HTTPS "POST" request is sent
+    When the request "retrieveType" is sent
     Then the response status code is 200
     And the response body complies with the 200RetrieveType schema at "/components/schemas/200RetrieveType"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -147,6 +154,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
 
   # Generic 400 errors
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrieveType_400.1_schema_not_compliant
   Scenario: Invalid Argument. Generic Syntax Exception
     Given the request body is set to any value which is not compliant with the schema at "/components/schemas/RequestBody"
@@ -158,6 +166,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrieveType_400.2_no_request_body
   Scenario: Missing request body
     Given the request body is not included
@@ -169,6 +178,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrieveType_400.3_device_empty
   Scenario: The device value is an empty object
     Given the request body property "$.device" is set to: {}
@@ -180,12 +190,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrieveType_400.4_device_identifiers_not_schema_compliant
   # Test every type of identifier even if not supported by the implementation
   # Note that device schema validation errors (if any) should be thrown even if a 3-legged access token is being used
   Scenario Outline: Some device identifier value does not comply with the schema
-    Given the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
-    And a 2-legged or 3-legged access token is being used
+    Given a valid 2-legged or 3-legged access token is being used
+    And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
     When the request "retrieveType" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -201,10 +212,12 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
       | $.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
       | $.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
+  # This scenario is only valid for 2-legged access tokens
   # The maximum is considered in the schema so a generic schema validator may fail and generate a 400 INVALID_ARGUMENT without further distinction, and both could be accepted
   @DeviceIdentifier_retrieveType_400.5_out_of_range_port
   Scenario: Out of range port
-    Given the request body property  "$.device.ipv4Address.publicPort" is set to a value not between 0 and 65535
+    Given the header "Authorization" is set to a valid access token that does not identify a device
+    And the request body property  "$.device.ipv4Address.publicPort" is set to a value not between 0 and 65535
     When the request "retrieveType" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -251,9 +264,10 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
 
   # Generic 403 errors
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrieveType_403.1_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope device-identifier:retrieve-type
+    Given the header "Authorization" is set to a valid access token that does not include scope device-identifier:retrieve-type
     When the request "retrieveType" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -264,10 +278,10 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
 
   # Generic 404 errors
 
-  # Typically with a 2-legged access token when the identified device is managed by a different API provider
+  # This scenario is valid only for 2-legged access tokens
   @DeviceIdentifier_retrieveType_404.1_device_not_found
   Scenario: An identifier cannot be matched to a valid device
-    Given that the device cannot be identified from the access token
+    Given the header "Authorization" is set to a valid access token that does not identify a device
     And the request body property "$.device" is compliant with the request body schema but does not identify a valid device
     When the request "retrieveType" is sent
     Then the response status code is 404
@@ -279,9 +293,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
 
   # Generic 422 errors
 
+  # This scenario is valid only for 2-legged access tokens
   @DeviceIdentifier_retrieveType_422.1_device_identifiers_unsupported
   Scenario: None of the provided device identifiers is supported by the implementation
     Given that some type of device identifiers are not supported by the implementation
+    And the header "Authorization" is set to a valid access token that does not identify a device
     And the request body property "$.device" only includes device identifiers not supported by the implementation
     When the request "retrieveType" is sent
     Then the response status code is 422
@@ -291,10 +307,13 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
+  # This scenario is valid for both 2-legged and 3-legged access tokens
   @DeviceIdentifier_retrieveType_422.2_device_not_supported
   Scenario: Service not available for the device
-    Given that service is not supported for all devices commercialized by the operator
-    And the service is not applicable for the device identified by the token or provided in the request body
+    #  The service may not be application due to, for example, line type, policy, regulation, or no deterministic device information being available
+    Given that the retrieveType service is not applicable for the identified device
+    And a valid 2-legged or 3-legged access token is being used
+    And a valid device is identified by the access token or the request body property "$.device"
     When the request "retrieveType" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -303,7 +322,7 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user friendly text
 
-  # Typically with a 2-legged access token
+  # This scenario is valid only for 2-legged access tokens
   @DeviceIdentifier_retrieveType_422.3_unidentifiable_device
   Scenario: Device not included and cannot be deduced from the access token
     Given the header "Authorization" is set to a valid access token which does not identify a device
@@ -316,12 +335,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response property "$.code" is "MISSING_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
-  # Typically with a 3-legged access token
+  # This scenario is valid only for 3-legged access tokens
   @DeviceIdentifier_retrieveType_422.4_device_token_mismatch
-  Scenario: Inconsistent access token context for the device
-    # To test this, a token has to be obtained for a different device
-    Given the request body property "$.device" is set to a valid testing device
-    And the header "Authorization" is set to a valid access token obtained for a different device
+  Scenario: Explicit device identifier provided when a 3-legged access token identifies a different device
+    Given the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
+    And the request body property "$.device" exists and identifies DEVICE2 containing SIMCARD2
     When the request "retrieveType" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -330,11 +348,11 @@ Feature: Camara Mobile Device Identifer API, vwip - Operation: retrieveType
     And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
     And the response property "$.message" contains a user friendly text
 
-  # Typically with a 3-legged access token
+  # This scenario is valid only for 3-legged access tokens
   @DeviceIdentifier_retrieveType_422.5_unnecessary_device_identifier_in_request
-  Scenario: Explicit device identifier provided when device is identified by the access token
-    Given the request body property "$.device" is set to a valid testing device
-    And the header "Authorization" is set to a valid access token for that same device
+  Scenario: Explicit device identifier provided when a 3-legged access token identifies the same device
+    Given the header "Authorization" is set to a valid access token that identifies DEVICE1 containing SIMCARD1
+    And the request body property "$.device" exists and also identifies DEVICE1 containing SIMCARD1
     When the request "retrieveType" is sent
     Then the response status code is 422
     And the response header "x-correlator" has same value as the request header "x-correlator"


### PR DESCRIPTION
#### What type of PR is this?
* tests

#### What this PR does / why we need it:
Applicability of tests for 2-legged and/or 3-legged access tokens was not clear. This PR adds an explicit clarifications, and makes other changes as necessary.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #158 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Update and clarify tests for applicability to 2-legged and/or 3-legged access tokens
```

#### Additional documentation 
None